### PR TITLE
Fix npm test script to run lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     ]
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "npm run lint",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "tailwind:build": "npx tailwindcss -i ./src/styles/tailwind.css -o ./public/assets/css/style.css --minify",

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ Configuration files for ESLint, Prettier, Tailwind and Husky live in the reposit
 
 - `npm run tailwind:build` – compile Tailwind to `public/assets/css/style.css`.
 - `npm run tailwind:watch` – watch Tailwind source files during development.
-- `npm run lint` / `npm run lint:fix` – run ESLint on the codebase.
+- `npm test` / `npm run lint` / `npm run lint:fix` – run ESLint on the codebase.
 - `npm run format` / `npm run format:check` – format files with Prettier.
 
 Before committing, Husky runs `lint-staged` to lint and format staged JavaScript, HTML and CSS changes automatically.


### PR DESCRIPTION
## Summary
- replace the failing placeholder `npm test` implementation with a call to the lint script
- document that `npm test` now acts as an alias of the lint task in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e7d0e7e8c883218a80d6dd72aaca39