### PR TITLE
Simplify public layout with basic styling

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,6 +23,11 @@ export default [
         navigator: "readonly",
         FormData: "readonly",
         URLSearchParams: "readonly",
+        URL: "readonly",
+        localStorage: "readonly",
+        fetch: "readonly",
+        Headers: "readonly",
+        CustomEvent: "readonly",
         // legg til 'module'/'require' hvis du bruker CommonJS
       },
     },

--- a/public/allListing.html
+++ b/public/allListing.html
@@ -3,62 +3,84 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>All listings | Semester Project 2</title>
+    <title>Listings | Auction House</title>
     <link rel="stylesheet" href="./assets/css/style.css" />
   </head>
-  <body class="page page--listings">
-    <header class="page__header">
-      <div class="page__header-inner">
-        <h1>Browse Listings</h1>
-        <p>Explore every listing currently available on the platform.</p>
+  <body>
+    <header class="site-header">
+      <div class="wrapper site-header__inner">
+        <a class="brand" href="./index.html">Auction House</a>
+        <nav class="site-nav" aria-label="Main navigation">
+          <ul class="site-nav__list">
+            <li><a class="site-nav__link" href="./index.html">Home</a></li>
+            <li>
+              <a
+                class="site-nav__link"
+                href="./allListing.html"
+                aria-current="page"
+                >Listings</a
+              >
+            </li>
+            <li data-auth="signed-in" hidden>
+              <span class="badge" data-user-credits></span>
+            </li>
+            <li data-auth="signed-in" hidden>
+              <span class="site-nav__user"
+                >Hi, <strong data-user-name></strong
+              ></span>
+            </li>
+            <li data-auth="signed-in" hidden>
+              <a class="site-nav__link" href="./profile.html" data-profile-link
+                >My profile</a
+              >
+            </li>
+            <li data-auth="signed-out">
+              <a class="site-nav__link" href="./register.html">Register</a>
+            </li>
+            <li data-auth="signed-out">
+              <a class="site-nav__link" href="./login.html">Log in</a>
+            </li>
+            <li data-auth="signed-in" hidden>
+              <button class="site-nav__button" type="button" data-logout>
+                Log out
+              </button>
+            </li>
+          </ul>
+        </nav>
       </div>
     </header>
 
-    <nav class="page__nav" aria-label="Main navigation">
-      <ul class="page__nav-list">
-        <li><a href="./index.html">Home</a></li>
-        <li><a href="./login.html">Log in</a></li>
-        <li><a href="./register.html">Register</a></li>
-        <li>
-          <a href="./allListing.html" aria-current="page">All listings</a>
-        </li>
-        <li><a href="./profile.html">Profile</a></li>
-      </ul>
-    </nav>
-
-    <main class="page__main">
-      <section class="card">
-        <header class="card__header">
-          <h2>Search</h2>
-        </header>
-        <form class="form form--filters" data-filter-form>
-          <label class="form__field">
-            <span>Keyword</span>
+    <main class="wrapper stack">
+      <section class="hero-card hero-card--left">
+        <h1>Browse live listings</h1>
+        <p>
+          Search by keyword to find auctions ending soon or items from your
+          favourite sellers.
+        </p>
+        <form class="search-form" data-search-form>
+          <div class="search-form__fields">
             <input type="search" name="query" placeholder="Search listings" />
-          </label>
-          <label class="form__field">
-            <span>Category</span>
-            <select name="category">
-              <option value="">All categories</option>
-              <option value="assignment">Assignments</option>
-              <option value="resource">Resources</option>
-              <option value="event">Events</option>
-            </select>
-          </label>
+            <button type="submit" class="button">Search</button>
+          </div>
         </form>
+        <p class="section__status" data-listings-status hidden></p>
       </section>
 
-      <section class="card">
-        <header class="card__header">
-          <h2>Results</h2>
-          <p class="card__meta"><span data-results-count>0</span> listings</p>
-        </header>
-        <ul class="listing-grid" data-listings></ul>
+      <section class="section">
+        <div class="section__header">
+          <h2>Available listings</h2>
+          <p class="section__status">
+            Showing <span data-results-count>0</span> results
+          </p>
+        </div>
+        <ul class="listing-list" data-listings></ul>
       </section>
     </main>
 
-    <footer class="page__footer">
-      &copy; <span data-year></span> Semester Project 2 Team
+    <footer class="site-footer">
+      <div class="wrapper site-footer__inner">
+        <p>&copy; <span data-year></span> Auction House</p>
+      </div>
     </footer>
 
     <script type="module" src="./assets/js/allListing.js"></script>

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -1,610 +1,465 @@
 *,
-:after,
-:before {
-  --tw-border-spacing-x: 0;
-  --tw-border-spacing-y: 0;
-  --tw-translate-x: 0;
-  --tw-translate-y: 0;
-  --tw-rotate: 0;
-  --tw-skew-x: 0;
-  --tw-skew-y: 0;
-  --tw-scale-x: 1;
-  --tw-scale-y: 1;
-  --tw-pan-x: ;
-  --tw-pan-y: ;
-  --tw-pinch-zoom: ;
-  --tw-scroll-snap-strictness: proximity;
-  --tw-gradient-from-position: ;
-  --tw-gradient-via-position: ;
-  --tw-gradient-to-position: ;
-  --tw-ordinal: ;
-  --tw-slashed-zero: ;
-  --tw-numeric-figure: ;
-  --tw-numeric-spacing: ;
-  --tw-numeric-fraction: ;
-  --tw-ring-inset: ;
-  --tw-ring-offset-width: 0px;
-  --tw-ring-offset-color: #fff;
-  --tw-ring-color: rgba(59, 130, 246, 0.5);
-  --tw-ring-offset-shadow: 0 0 #0000;
-  --tw-ring-shadow: 0 0 #0000;
-  --tw-shadow: 0 0 #0000;
-  --tw-shadow-colored: 0 0 #0000;
-  --tw-blur: ;
-  --tw-brightness: ;
-  --tw-contrast: ;
-  --tw-grayscale: ;
-  --tw-hue-rotate: ;
-  --tw-invert: ;
-  --tw-saturate: ;
-  --tw-sepia: ;
-  --tw-drop-shadow: ;
-  --tw-backdrop-blur: ;
-  --tw-backdrop-brightness: ;
-  --tw-backdrop-contrast: ;
-  --tw-backdrop-grayscale: ;
-  --tw-backdrop-hue-rotate: ;
-  --tw-backdrop-invert: ;
-  --tw-backdrop-opacity: ;
-  --tw-backdrop-saturate: ;
-  --tw-backdrop-sepia: ;
-  --tw-contain-size: ;
-  --tw-contain-layout: ;
-  --tw-contain-paint: ;
-  --tw-contain-style: ;
-}
-::backdrop {
-  --tw-border-spacing-x: 0;
-  --tw-border-spacing-y: 0;
-  --tw-translate-x: 0;
-  --tw-translate-y: 0;
-  --tw-rotate: 0;
-  --tw-skew-x: 0;
-  --tw-skew-y: 0;
-  --tw-scale-x: 1;
-  --tw-scale-y: 1;
-  --tw-pan-x: ;
-  --tw-pan-y: ;
-  --tw-pinch-zoom: ;
-  --tw-scroll-snap-strictness: proximity;
-  --tw-gradient-from-position: ;
-  --tw-gradient-via-position: ;
-  --tw-gradient-to-position: ;
-  --tw-ordinal: ;
-  --tw-slashed-zero: ;
-  --tw-numeric-figure: ;
-  --tw-numeric-spacing: ;
-  --tw-numeric-fraction: ;
-  --tw-ring-inset: ;
-  --tw-ring-offset-width: 0px;
-  --tw-ring-offset-color: #fff;
-  --tw-ring-color: rgba(59, 130, 246, 0.5);
-  --tw-ring-offset-shadow: 0 0 #0000;
-  --tw-ring-shadow: 0 0 #0000;
-  --tw-shadow: 0 0 #0000;
-  --tw-shadow-colored: 0 0 #0000;
-  --tw-blur: ;
-  --tw-brightness: ;
-  --tw-contrast: ;
-  --tw-grayscale: ;
-  --tw-hue-rotate: ;
-  --tw-invert: ;
-  --tw-saturate: ;
-  --tw-sepia: ;
-  --tw-drop-shadow: ;
-  --tw-backdrop-blur: ;
-  --tw-backdrop-brightness: ;
-  --tw-backdrop-contrast: ;
-  --tw-backdrop-grayscale: ;
-  --tw-backdrop-hue-rotate: ;
-  --tw-backdrop-invert: ;
-  --tw-backdrop-opacity: ;
-  --tw-backdrop-saturate: ;
-  --tw-backdrop-sepia: ;
-  --tw-contain-size: ;
-  --tw-contain-layout: ;
-  --tw-contain-paint: ;
-  --tw-contain-style: ;
-} /*! tailwindcss v3.4.17 | MIT License | https://tailwindcss.com*/
-*,
-:after,
-:before {
+*::before,
+*::after {
   box-sizing: border-box;
-  border: 0 solid #e5e7eb;
 }
-:after,
-:before {
-  --tw-content: "";
-}
-:host,
-html {
-  line-height: 1.5;
-  -webkit-text-size-adjust: 100%;
-  -moz-tab-size: 4;
-  -o-tab-size: 4;
-  tab-size: 4;
-  font-family:
-    ui-sans-serif,
-    system-ui,
-    sans-serif,
-    Apple Color Emoji,
-    Segoe UI Emoji,
-    Segoe UI Symbol,
-    Noto Color Emoji;
-  font-feature-settings: normal;
-  font-variation-settings: normal;
-  -webkit-tap-highlight-color: transparent;
-}
+
+html,
 body {
   margin: 0;
-  line-height: inherit;
-}
-hr {
-  height: 0;
-  color: inherit;
-  border-top-width: 1px;
-}
-abbr:where([title]) {
-  -webkit-text-decoration: underline dotted;
-  text-decoration: underline dotted;
-}
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-size: inherit;
-  font-weight: inherit;
-}
-a {
-  color: inherit;
-  text-decoration: inherit;
-}
-b,
-strong {
-  font-weight: bolder;
-}
-code,
-kbd,
-pre,
-samp {
-  font-family:
-    ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    Monaco,
-    Consolas,
-    Liberation Mono,
-    Courier New,
-    monospace;
-  font-feature-settings: normal;
-  font-variation-settings: normal;
-  font-size: 1em;
-}
-small {
-  font-size: 80%;
-}
-sub,
-sup {
-  font-size: 75%;
-  line-height: 0;
-  position: relative;
-  vertical-align: baseline;
-}
-sub {
-  bottom: -0.25em;
-}
-sup {
-  top: -0.5em;
-}
-table {
-  text-indent: 0;
-  border-color: inherit;
-  border-collapse: collapse;
-}
-button,
-input,
-optgroup,
-select,
-textarea {
-  font-family: inherit;
-  font-feature-settings: inherit;
-  font-variation-settings: inherit;
-  font-size: 100%;
-  font-weight: inherit;
-  line-height: inherit;
-  letter-spacing: inherit;
-  color: inherit;
-  margin: 0;
   padding: 0;
-}
-button,
-select {
-  text-transform: none;
-}
-button,
-input:where([type="button"]),
-input:where([type="reset"]),
-input:where([type="submit"]) {
-  -webkit-appearance: button;
-  background-color: transparent;
-  background-image: none;
-}
-:-moz-focusring {
-  outline: auto;
-}
-:-moz-ui-invalid {
-  box-shadow: none;
-}
-progress {
-  vertical-align: baseline;
-}
-::-webkit-inner-spin-button,
-::-webkit-outer-spin-button {
-  height: auto;
-}
-[type="search"] {
-  -webkit-appearance: textfield;
-  outline-offset: -2px;
-}
-::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
-::-webkit-file-upload-button {
-  -webkit-appearance: button;
-  font: inherit;
-}
-summary {
-  display: list-item;
-}
-blockquote,
-dd,
-dl,
-figure,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-hr,
-p,
-pre {
-  margin: 0;
-}
-fieldset {
-  margin: 0;
-}
-fieldset,
-legend {
-  padding: 0;
-}
-menu,
-ol,
-ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-dialog {
-  padding: 0;
-}
-textarea {
-  resize: vertical;
-}
-input::-moz-placeholder,
-textarea::-moz-placeholder {
-  opacity: 1;
-  color: #9ca3af;
-}
-input::placeholder,
-textarea::placeholder {
-  opacity: 1;
-  color: #9ca3af;
-}
-[role="button"],
-button {
-  cursor: pointer;
-}
-:disabled {
-  cursor: default;
-}
-audio,
-canvas,
-embed,
-iframe,
-img,
-object,
-svg,
-video {
-  display: block;
-  vertical-align: middle;
-}
-img,
-video {
-  max-width: 100%;
-  height: auto;
-}
-[hidden]:where(:not([hidden="until-found"])) {
-  display: none;
-}
-:root {
-  color-scheme: light dark;
-  font-family: "Inter", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-  line-height: 1.6;
-  background-color: #f5f5f5;
 }
 
 body {
-  margin: 0;
-  background: linear-gradient(180deg, #f5f5f5 0%, #ffffff 35%);
-  color: #1a1a1a;
   min-height: 100vh;
-}
-
-body.theme--dark {
-  background: linear-gradient(180deg, #111827 0%, #1f2937 40%);
-  color: #f9fafb;
-}
-
-.page {
+  font-family: "Inter", "Segoe UI", -apple-system, BlinkMacSystemFont, sans-serif;
+  background-color: #f4f4f5;
+  color: #1f2933;
+  line-height: 1.6;
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
 }
 
-.page__header {
-  background: rgba(22, 101, 216, 0.9);
-  color: #fff;
-  padding: clamp(2rem, 5vw, 3.5rem) 1rem;
-  text-align: center;
-  position: relative;
-  overflow: hidden;
-}
-
-.page__header::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background:
-    radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.25), transparent 55%),
-    radial-gradient(circle at 80% 20%, rgba(255, 255, 255, 0.15), transparent 60%);
-  pointer-events: none;
-}
-
-.page__header-inner {
-  position: relative;
-  z-index: 1;
-  max-width: 48rem;
-  margin: 0 auto;
-}
-
-.page__nav {
-  background: rgba(255, 255, 255, 0.95);
-  backdrop-filter: blur(8px);
-  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
-}
-
-.theme--dark .page__nav {
-  background: rgba(15, 23, 42, 0.85);
-  border-bottom-color: rgba(148, 163, 184, 0.25);
-}
-
-.page__nav-list {
-  display: flex;
-  justify-content: center;
-  gap: 1rem;
-  padding: 0.75rem 1rem;
-  margin: 0 auto;
-  list-style: none;
-  max-width: 60rem;
-}
-
-.page__nav-list a {
+a {
   color: inherit;
   text-decoration: none;
-  font-weight: 500;
-  padding: 0.25rem 0.75rem;
-  border-radius: 999px;
-  transition: background-color 150ms ease, color 150ms ease;
 }
 
-.page__nav-list a:hover,
-.page__nav-list a:focus {
-  background: rgba(37, 99, 235, 0.1);
-  color: rgba(37, 99, 235, 1);
+a:hover,
+a:focus {
+  text-decoration: underline;
 }
 
-.page__nav-list a[aria-current="page"] {
-  background: rgba(37, 99, 235, 0.15);
-  color: rgba(37, 99, 235, 1);
+button,
+input,
+textarea {
+  font: inherit;
 }
 
-.theme--dark .page__nav-list a:hover,
-.theme--dark .page__nav-list a:focus,
-.theme--dark .page__nav-list a[aria-current="page"] {
-  background: rgba(191, 219, 254, 0.16);
-  color: rgba(191, 219, 254, 1);
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
 }
 
-.page__main {
-  flex: 1;
-  max-width: 60rem;
-  width: min(90vw, 60rem);
-  margin: -2rem auto 3rem;
-  padding: 0;
-  display: grid;
-  gap: 1.5rem;
-}
-
-.card {
-  background: #fff;
-  border-radius: 1.25rem;
-  padding: clamp(1.5rem, 4vw, 2.5rem);
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.1);
-}
-
-.theme--dark .card {
-  background: rgba(15, 23, 42, 0.85);
-  box-shadow: 0 20px 45px rgba(2, 6, 23, 0.4);
-}
-
-.card__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  gap: 1rem;
-  margin-bottom: 1rem;
-}
-
-.card__meta {
-  color: rgba(15, 23, 42, 0.6);
-  font-size: 0.95rem;
-}
-
-.theme--dark .card__meta {
-  color: rgba(226, 232, 240, 0.7);
-}
-
-.pill-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.pill-list li {
-  background: rgba(37, 99, 235, 0.1);
-  color: rgba(37, 99, 235, 1);
-  padding: 0.4rem 0.85rem;
-  border-radius: 999px;
-  font-size: 0.95rem;
-}
-
-.theme--dark .pill-list li {
-  background: rgba(191, 219, 254, 0.16);
-  color: rgba(191, 219, 254, 1);
-}
-
-.card--form {
-  max-width: 32rem;
+.wrapper {
+  width: min(960px, 100%);
   margin: 0 auto;
+  padding: 0 1.5rem;
 }
 
-.form {
-  display: grid;
+.site-header {
+  background-color: #ffffff;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.site-header__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 1rem;
-  margin-top: 1.5rem;
+  flex-wrap: wrap;
+  padding: 1rem 0;
 }
 
-.form__field {
-  display: grid;
-  gap: 0.5rem;
-  font-weight: 500;
-}
-
-.form__field input,
-.form__field select {
-  border-radius: 0.75rem;
-  border: 1px solid rgba(15, 23, 42, 0.12);
-  padding: 0.75rem 1rem;
-  font-size: 1rem;
-}
-
-.form__field input:focus,
-.form__field select:focus {
-  outline: 2px solid rgba(37, 99, 235, 0.4);
-  outline-offset: 2px;
-}
-
-.form__status {
+.brand {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   font-size: 0.95rem;
-  margin-top: 0.25rem;
 }
 
-.form__status--error {
-  color: #dc2626;
+.site-nav__list {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  flex-wrap: wrap;
 }
 
-.form__status--success {
-  color: #16a34a;
+.site-nav__link,
+.site-nav__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-size: 0.9rem;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.site-nav__link[aria-current="page"] {
+  background-color: #e5e7eb;
+  border-color: #d1d5db;
+}
+
+.site-nav__button {
+  border-color: #d1d5db;
+  background-color: #ffffff;
+}
+
+.site-nav__button:hover,
+.site-nav__button:focus {
+  background-color: #f3f4f6;
+}
+
+.site-nav__user {
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background-color: #e0e7ff;
+  color: #1e3a8a;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+main {
+  flex: 1;
+  padding: 2rem 0 3rem;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.hero-card,
+.section {
+  background-color: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+.hero-card > *:last-child,
+.section > *:last-child {
+  margin-bottom: 0;
+}
+
+.hero-card h1,
+.section h1,
+.section h2,
+.section h3 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+}
+
+.page-title {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: clamp(1.75rem, 4vw, 2.25rem);
+}
+
+.page-lede {
+  margin: 0 0 1.25rem;
+  color: #4b5563;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+  color: #6b7280;
+  margin: 0 0 0.75rem;
+}
+
+.search-form {
+  margin-top: 1rem;
+}
+
+.search-form__fields {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.search-form input[type="search"] {
+  flex: 1;
+  min-width: 220px;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  background-color: #ffffff;
 }
 
 .button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 1.1rem;
+  border-radius: 8px;
   border: none;
-  border-radius: 999px;
-  padding: 0.75rem 1.5rem;
-  font-size: 1rem;
+  background-color: #2563eb;
+  color: #ffffff;
   font-weight: 600;
-  color: #fff;
-  background: linear-gradient(90deg, #2563eb, #7c3aed);
   cursor: pointer;
-  transition: transform 150ms ease, box-shadow 150ms ease;
+  text-decoration: none;
 }
 
 .button:hover,
 .button:focus {
-  transform: translateY(-1px);
-  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
+  background-color: #1d4ed8;
+  text-decoration: none;
 }
 
-.listing-grid {
-  display: grid;
+.button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.button--outline {
+  background-color: #ffffff;
+  border: 1px solid #d1d5db;
+  color: #1f2933;
+}
+
+.button--outline:hover,
+.button--outline:focus {
+  background-color: #f3f4f6;
+}
+
+.section__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 1.5rem;
+}
+
+.section__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.section__status {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #6b7280;
+}
+
+.section__status[data-tone="error"] {
+  color: #b91c1c;
+}
+
+.section__status[data-tone="warning"] {
+  color: #b45309;
+}
+
+.topics {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 1.25rem;
+}
+
+.topic-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background-color: #e5e7eb;
+  font-size: 0.8rem;
+  color: #374151;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.form label span {
+  display: block;
+  font-weight: 600;
+  font-size: 0.9rem;
+  margin-bottom: 0.35rem;
+}
+
+.form input,
+.form textarea {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  background-color: #ffffff;
+}
+
+.form__checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.form__checkbox input {
+  width: auto;
+}
+
+.hero-card--listing {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.hero-card--left {
+  text-align: left;
+}
+
+@media (min-width: 720px) {
+  .hero-card--listing {
+    grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
+    align-items: start;
+  }
+}
+
+.hero-card__media {
+  border-radius: 10px;
+  background-color: #f3f4f6;
+  min-height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.hero-card__media img[hidden] {
+  display: none;
+}
+
+.hero-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.listing-list {
+  list-style: none;
   margin: 0;
   padding: 0;
-  list-style: none;
-}
-
-.listing-grid li {
-  border-radius: 1rem;
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  padding: 1.25rem;
-}
-
-.definition-list {
   display: grid;
   gap: 1rem;
 }
 
-.definition-list div {
-  display: grid;
-  gap: 0.25rem;
+@media (min-width: 640px) {
+  .listing-list {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  }
 }
 
-.definition-list dt {
-  font-size: 0.875rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: rgba(15, 23, 42, 0.6);
+.listing-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 1rem;
+  background-color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
-.definition-list dd {
+.listing-card__media {
+  border-radius: 8px;
+  overflow: hidden;
+  background-color: #f3f4f6;
+  aspect-ratio: 4 / 3;
+}
+
+.listing-card__title {
   margin: 0;
-  font-size: 1.05rem;
+  font-size: 1.1rem;
+}
+
+.listing-card__title a {
+  text-decoration: none;
+}
+
+.listing-card__title a:hover,
+.listing-card__title a:focus {
+  text-decoration: underline;
+}
+
+.listing-card__seller {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #6b7280;
+}
+
+.listing-card__description {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.95rem;
+}
+
+.listing-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.listing-card__meta--stack {
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.listing-card--empty {
+  text-align: center;
+  color: #6b7280;
+  font-size: 0.95rem;
+}
+
+.listing-bids {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.listing-bids li {
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  background-color: #f9fafb;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.profile__credits {
   font-weight: 600;
 }
 
-.page__footer {
-  text-align: center;
-  padding: 2rem 1rem 3rem;
-  color: rgba(15, 23, 42, 0.6);
+.site-footer {
+  background-color: #ffffff;
+  border-top: 1px solid #e5e7eb;
 }
 
-.theme--dark .page__footer {
-  color: rgba(226, 232, 240, 0.7);
-}
-
-@media (max-width: 48rem) {
-  .card__header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .page__nav-list {
-    flex-wrap: wrap;
-  }
+.site-footer__inner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem 0;
+  font-size: 0.85rem;
+  color: #6b7280;
 }

--- a/public/assets/js/allListing.js
+++ b/public/assets/js/allListing.js
@@ -1,13 +1,62 @@
-import { listingSeedData } from "./shared/data.js";
+/* eslint-env browser */
+
+import { getListings, searchListings } from "./shared/api.js";
+import { fallbackListings } from "./shared/data.js";
 import { formatDate, initPageChrome, renderCount } from "./shared/page.js";
 
 const teardown = initPageChrome();
 
-const listings = listingSeedData;
-
 const listElement = document.querySelector("[data-listings]");
-const filterForm = document.querySelector("[data-filter-form]");
 const resultsCount = document.querySelector("[data-results-count]");
+const statusElement = document.querySelector("[data-listings-status]");
+const searchForm = document.querySelector("[data-search-form]");
+const initialParams = new URLSearchParams(window.location.search);
+const initialQuery = initialParams.get("query");
+
+const DEFAULT_QUERY = {
+  sort: "created",
+  sortOrder: "desc",
+  _seller: true,
+  _bids: true,
+  limit: 40,
+};
+
+const createListingCard = (listing) => {
+  const listItem = document.createElement("li");
+  listItem.className = "listing-card";
+
+  const media = listing.media?.[0];
+  const bids = listing._count?.bids ?? 0;
+  const sellerName = listing.seller?.name || "Unknown seller";
+
+  listItem.innerHTML = `
+    <div class="listing-card__header">
+      <h3 class="listing-card__title">
+        <a href="./listing.html?id=${encodeURIComponent(listing.id)}">${listing.title}</a>
+      </h3>
+      <p class="listing-card__seller">${sellerName}</p>
+    </div>
+    <p class="listing-card__description">${listing.description || "No description provided."}</p>
+    <div class="listing-card__meta">
+      <span><strong>${bids}</strong> bids</span>
+      <span>Ends ${formatDate(listing.endsAt)}</span>
+    </div>
+  `;
+
+  if (media?.url) {
+    const figure = document.createElement("figure");
+    figure.className = "listing-card__media";
+
+    const image = document.createElement("img");
+    image.src = media.url;
+    image.alt = media.alt || listing.title;
+    figure.append(image);
+
+    listItem.prepend(figure);
+  }
+
+  return listItem;
+};
 
 const renderListings = (items) => {
   if (!listElement) {
@@ -16,67 +65,99 @@ const renderListings = (items) => {
 
   listElement.innerHTML = "";
 
+  if (!items.length) {
+    const emptyItem = document.createElement("li");
+    emptyItem.className = "listing-card listing-card--empty";
+    emptyItem.textContent = "No listings found. Try a different search.";
+    listElement.append(emptyItem);
+    renderCount(resultsCount, 0);
+    return;
+  }
+
   const fragment = document.createDocumentFragment();
-
   items.forEach((item) => {
-    const listItem = document.createElement("li");
-    listItem.innerHTML = `
-      <article>
-        <header class="card__header">
-          <h3>${item.title}</h3>
-          <span class="card__meta">${item.status}</span>
-        </header>
-        <p>${item.description}</p>
-        <dl class="definition-list">
-          <div>
-            <dt>Category</dt>
-            <dd>${item.category}</dd>
-          </div>
-          <div>
-            <dt>Deadline</dt>
-            <dd>${formatDate(item.deadline)}</dd>
-          </div>
-        </dl>
-        <p><a href="./listing.html?id=${encodeURIComponent(item.id)}">View details</a></p>
-      </article>
-    `;
-
-    fragment.append(listItem);
+    fragment.append(createListingCard(item));
   });
 
   listElement.append(fragment);
   renderCount(resultsCount, items.length);
 };
 
-const applyFilters = () => {
-  if (!filterForm) {
-    renderListings(listings);
+const setStatus = (message, tone = "info") => {
+  if (!statusElement) {
     return;
   }
 
-  const formData = new FormData(filterForm);
-  const query = String(formData.get("query") ?? "").toLowerCase();
-  const category = String(formData.get("category") ?? "");
+  statusElement.textContent = message;
+  if (!message) {
+    statusElement.hidden = true;
+    delete statusElement.dataset.tone;
+    return;
+  }
 
-  const filtered = listings.filter((listing) => {
-    const matchesQuery = query
-      ? listing.title.toLowerCase().includes(query) ||
-        listing.description.toLowerCase().includes(query)
-      : true;
-    const matchesCategory = category ? listing.category === category : true;
-
-    return matchesQuery && matchesCategory;
-  });
-
-  renderListings(filtered);
+  statusElement.hidden = false;
+  statusElement.dataset.tone = tone;
 };
 
-if (filterForm) {
-  filterForm.addEventListener("input", applyFilters);
-  filterForm.addEventListener("change", applyFilters);
+const loadListings = async (query) => {
+  setStatus("Loading listings…", "info");
+
+  try {
+    const response = query
+      ? await searchListings(query, DEFAULT_QUERY)
+      : await getListings(DEFAULT_QUERY);
+
+    const items =
+      Array.isArray(response?.data) && response.data.length
+        ? response.data
+        : [];
+
+    if (!items.length) {
+      setStatus("No listings matched your search.", "warning");
+      renderListings([]);
+      return;
+    }
+
+    setStatus("");
+    renderListings(items);
+  } catch (error) {
+    console.error(error);
+    setStatus(
+      error.message ||
+        "We couldn't load listings right now. Showing examples instead.",
+      "error",
+    );
+    renderListings(fallbackListings);
+  }
+};
+
+if (searchForm) {
+  if (initialQuery) {
+    const input = searchForm.querySelector('input[name="query"]');
+    if (input) {
+      input.value = initialQuery;
+    }
+  }
+
+  searchForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const formData = new FormData(searchForm);
+    const query = String(formData.get("query") || "").trim();
+
+    if (!query) {
+      loadListings();
+      return;
+    }
+
+    loadListings(query);
+  });
 }
 
-renderListings(listings);
+if (initialQuery) {
+  loadListings(initialQuery);
+} else {
+  loadListings();
+}
 
 window.addEventListener("unload", () => {
   if (typeof teardown === "function") {

--- a/public/assets/js/listing.js
+++ b/public/assets/js/listing.js
@@ -1,46 +1,193 @@
-import { listingSeedData } from "./shared/data.js";
+/* eslint-env browser */
+
+import { getListing } from "./shared/api.js";
+import { fallbackListings } from "./shared/data.js";
 import { formatDate, initPageChrome } from "./shared/page.js";
 
 const teardown = initPageChrome();
 
-const titleElement = document.querySelector("[data-listing-title]");
+const titleElements = document.querySelectorAll("[data-listing-title]");
+const descriptionElements = document.querySelectorAll(
+  "[data-listing-description]",
+);
+const sellerElements = document.querySelectorAll("[data-listing-seller]");
+const deadlineElements = document.querySelectorAll("[data-listing-deadline]");
+const bidCountElements = document.querySelectorAll("[data-listing-bid-count]");
 const statusElement = document.querySelector("[data-listing-status]");
-const descriptionElement = document.querySelector("[data-listing-description]");
-const ownerElement = document.querySelector("[data-listing-owner]");
-const deadlineElement = document.querySelector("[data-listing-deadline]");
-const categoryElement = document.querySelector("[data-listing-category]");
+const imageElement = document.querySelector("[data-listing-image]");
+const bidsContainer = document.querySelector("[data-bid-list]");
 
 const params = new URLSearchParams(window.location.search);
 const listingId = params.get("id");
 
-const listing =
-  listingSeedData.find((item) => item.id === listingId) ?? listingSeedData[0];
-
-if (listing) {
-  if (titleElement) {
-    titleElement.textContent = listing.title;
+const setStatus = (message, tone = "info") => {
+  if (!statusElement) {
+    return;
   }
 
-  if (statusElement) {
-    statusElement.textContent = listing.status;
+  statusElement.textContent = message;
+  if (!message) {
+    statusElement.hidden = true;
+    delete statusElement.dataset.tone;
+    return;
   }
 
-  if (descriptionElement) {
-    descriptionElement.textContent = listing.description;
+  statusElement.hidden = false;
+  statusElement.dataset.tone = tone;
+};
+
+const assignTextContent = (elements, value) => {
+  if (!elements) {
+    return;
   }
 
-  if (ownerElement) {
-    ownerElement.textContent = listing.owner;
+  const text = value ?? "";
+
+  if (typeof elements.forEach === "function" && !elements.nodeType) {
+    elements.forEach((element) => {
+      element.textContent = text;
+    });
+    return;
   }
 
-  if (deadlineElement) {
-    deadlineElement.textContent = formatDate(listing.deadline);
+  if (elements) {
+    elements.textContent = text;
+  }
+};
+
+const renderBids = (bids = []) => {
+  if (!bidsContainer) {
+    return;
   }
 
-  if (categoryElement) {
-    categoryElement.textContent = listing.category;
+  bidsContainer.innerHTML = "";
+
+  if (!bids.length) {
+    const empty = document.createElement("li");
+    empty.className = "listing-bid listing-bid--empty";
+    empty.textContent = "No bids yet. Be the first to place one!";
+    bidsContainer.append(empty);
+    return;
   }
-}
+
+  const fragment = document.createDocumentFragment();
+  bids
+    .slice()
+    .sort((a, b) => Number(b.amount) - Number(a.amount))
+    .forEach((bid) => {
+      const item = document.createElement("li");
+      item.className = "listing-bid";
+      const bidder = bid.bidder?.name || "Anonymous";
+      item.innerHTML = `
+        <span>${bidder}</span>
+        <strong>${new Intl.NumberFormat().format(bid.amount)} credits</strong>
+        <time datetime="${bid.created}">${formatDate(bid.created)}</time>
+      `;
+      fragment.append(item);
+    });
+
+  bidsContainer.append(fragment);
+};
+
+const hydrateListing = (listing, { updateTitle = true } = {}) => {
+  if (!listing) {
+    return;
+  }
+
+  assignTextContent(titleElements, listing.title);
+  if (listing.title && updateTitle) {
+    document.title = `${listing.title} | Auction House`;
+  }
+  assignTextContent(
+    descriptionElements,
+    listing.description || "No description provided.",
+  );
+
+  const sellerName = listing.seller?.name || "Unknown seller";
+  assignTextContent(sellerElements, sellerName);
+
+  assignTextContent(deadlineElements, formatDate(listing.endsAt));
+  let isoDeadline = "";
+  if (listing.endsAt) {
+    const parsed = new Date(listing.endsAt);
+    if (!Number.isNaN(parsed.getTime())) {
+      isoDeadline = parsed.toISOString();
+    }
+  }
+  if (isoDeadline && deadlineElements) {
+    const assignDateTime = (element) => {
+      if (element?.tagName === "TIME") {
+        element.dateTime = isoDeadline;
+      }
+    };
+
+    if (
+      typeof deadlineElements.forEach === "function" &&
+      !deadlineElements.nodeType
+    ) {
+      deadlineElements.forEach(assignDateTime);
+    } else {
+      assignDateTime(deadlineElements);
+    }
+  }
+
+  const bids = listing._count?.bids ?? listing.bids?.length ?? 0;
+  assignTextContent(bidCountElements, new Intl.NumberFormat().format(bids));
+
+  if (imageElement) {
+    const media = listing.media?.[0];
+    if (media?.url) {
+      imageElement.src = media.url;
+      imageElement.alt = media.alt || listing.title;
+      imageElement.hidden = false;
+    } else {
+      imageElement.hidden = true;
+      imageElement.removeAttribute("src");
+      imageElement.removeAttribute("alt");
+    }
+  }
+
+  renderBids(listing.bids || []);
+};
+
+const loadListing = async () => {
+  if (!listingId) {
+    setStatus(
+      "We couldn't find that listing. Showing an example instead.",
+      "warning",
+    );
+    hydrateListing(fallbackListings[0], { updateTitle: false });
+    return;
+  }
+
+  setStatus("Loading listing details…", "info");
+
+  try {
+    const response = await getListing(listingId, {
+      _seller: true,
+      _bids: true,
+    });
+
+    const listing = response?.data;
+
+    if (!listing) {
+      throw new Error("Listing not found");
+    }
+
+    setStatus("");
+    hydrateListing(listing, { updateTitle: true });
+  } catch (error) {
+    console.error(error);
+    setStatus(
+      error.message ||
+        "We couldn't load this listing right now. Showing an example instead.",
+      "error",
+    );
+    hydrateListing(fallbackListings[0], { updateTitle: false });
+  }
+};
+
+loadListing();
 
 window.addEventListener("unload", () => {
   if (typeof teardown === "function") {

--- a/public/assets/js/login.js
+++ b/public/assets/js/login.js
@@ -1,23 +1,40 @@
+/* eslint-env browser */
+
+import {
+  emitAuthChanged,
+  getProfile,
+  loginUser,
+  setStoredAuth,
+} from "./shared/api.js";
 import { initPageChrome } from "./shared/page.js";
 
 const teardown = initPageChrome();
 
 const form = document.querySelector("[data-auth-form]");
 
-if (form) {
+const createStatusElement = () => {
   const status = document.createElement("p");
   status.className = "form__status";
   status.setAttribute("role", "status");
   status.setAttribute("aria-live", "polite");
   status.hidden = true;
+  return status;
+};
+
+if (form) {
+  const status = createStatusElement();
   form.append(status);
 
-  form.addEventListener("submit", (event) => {
+  form.addEventListener("submit", async (event) => {
     event.preventDefault();
+
+    if (form.dataset.submitting === "true") {
+      return;
+    }
 
     const formData = new FormData(form);
     const email = String(formData.get("email") ?? "").trim();
-    const password = String(formData.get("password") ?? "");
+    const password = String(formData.get("password") ?? "").trim();
 
     if (!email || !password) {
       status.hidden = false;
@@ -26,9 +43,55 @@ if (form) {
       return;
     }
 
-    status.hidden = false;
-    status.textContent = "Signing you in…";
-    status.className = "form__status form__status--success";
+    try {
+      form.dataset.submitting = "true";
+      status.hidden = false;
+      status.textContent = "Signing you in…";
+      status.className = "form__status";
+
+      const response = await loginUser({ email, password });
+      const auth = response?.data;
+
+      if (!auth?.accessToken) {
+        throw new Error("Login failed. Please try again.");
+      }
+
+      setStoredAuth(auth);
+      emitAuthChanged();
+
+      try {
+        const profileResponse = await getProfile(auth.name, {});
+        const profile = profileResponse?.data;
+        if (profile) {
+          const creditValue = Number(profile.credits ?? auth.credits ?? 0);
+          const credits = Number.isFinite(creditValue)
+            ? creditValue
+            : auth.credits;
+          setStoredAuth({ ...auth, credits });
+          emitAuthChanged();
+        }
+      } catch (profileError) {
+        console.warn("Unable to fetch profile after login", profileError);
+      }
+
+      status.textContent = "Signed in successfully. Redirecting…";
+      status.className = "form__status form__status--success";
+
+      window.setTimeout(() => {
+        const url = new URL("./profile.html", window.location.origin);
+        if (auth.name) {
+          url.searchParams.set("name", auth.name);
+        }
+        window.location.href = `${url.pathname}${url.search}`;
+      }, 800);
+    } catch (error) {
+      console.error(error);
+      status.hidden = false;
+      status.textContent = error.message || "Login failed. Please try again.";
+      status.className = "form__status form__status--error";
+    } finally {
+      form.dataset.submitting = "false";
+    }
   });
 }
 

--- a/public/assets/js/profile.js
+++ b/public/assets/js/profile.js
@@ -1,23 +1,205 @@
-import { profileSeedData } from "./shared/data.js";
-import { initPageChrome, renderCount } from "./shared/page.js";
+/* eslint-env browser */
+
+import {
+  emitAuthChanged,
+  getProfile,
+  getStoredAuth,
+  setStoredAuth,
+} from "./shared/api.js";
+import { fallbackProfile } from "./shared/data.js";
+import { formatDate, initPageChrome, renderCount } from "./shared/page.js";
 
 const teardown = initPageChrome();
 
-const nameElement = document.querySelector("[data-profile-name]");
-const emailElement = document.querySelector("[data-profile-email]");
-const activeElement = document.querySelector("[data-profile-active]");
-const completedElement = document.querySelector("[data-profile-completed]");
+const nameElements = document.querySelectorAll("[data-profile-name]");
+const emailElements = document.querySelectorAll("[data-profile-email]");
+const creditElements = document.querySelectorAll("[data-profile-credits]");
+const listingCountElements = document.querySelectorAll(
+  "[data-profile-listing-count]",
+);
+const winCountElements = document.querySelectorAll("[data-profile-win-count]");
+const listingsContainer = document.querySelector("[data-profile-listings]");
+const winsContainer = document.querySelector("[data-profile-wins]");
+const statusElement = document.querySelector("[data-profile-status]");
 
-if (nameElement) {
-  nameElement.textContent = profileSeedData.name;
-}
+const params = new URLSearchParams(window.location.search);
+const auth = getStoredAuth();
+const profileName = params.get("name") || auth?.name || "";
 
-if (emailElement) {
-  emailElement.textContent = profileSeedData.email;
-}
+const setStatus = (message, tone = "info") => {
+  if (!statusElement) {
+    return;
+  }
 
-renderCount(activeElement, profileSeedData.stats.active);
-renderCount(completedElement, profileSeedData.stats.completed);
+  statusElement.textContent = message;
+  if (!message) {
+    statusElement.hidden = true;
+    delete statusElement.dataset.tone;
+    return;
+  }
+
+  statusElement.hidden = false;
+  statusElement.dataset.tone = tone;
+};
+
+const assignText = (elements, value) => {
+  if (!elements) {
+    return;
+  }
+
+  const text = value ?? "";
+
+  if (typeof elements.forEach === "function" && !elements.nodeType) {
+    elements.forEach((element) => {
+      element.textContent = text;
+    });
+    return;
+  }
+
+  if (elements) {
+    elements.textContent = text;
+  }
+};
+
+const createListingItem = (listing) => {
+  const item = document.createElement("li");
+  item.className = "listing-card";
+
+  const media = listing.media?.[0];
+  if (media?.url) {
+    const figure = document.createElement("figure");
+    figure.className = "listing-card__media";
+
+    const image = document.createElement("img");
+    image.src = media.url;
+    image.alt = media.alt || listing.title;
+    figure.append(image);
+
+    item.append(figure);
+  }
+
+  const content = document.createElement("div");
+  content.className = "listing-card__body";
+
+  const title = document.createElement("h3");
+  title.className = "listing-card__title";
+  title.innerHTML = `<a href="./listing.html?id=${encodeURIComponent(listing.id)}">${listing.title}</a>`;
+  content.append(title);
+
+  const description = document.createElement("p");
+  description.className = "listing-card__description";
+  description.textContent = listing.description || "No description provided.";
+  content.append(description);
+
+  const meta = document.createElement("div");
+  meta.className = "listing-card__meta";
+  const bidCount = listing._count?.bids ?? listing.bids?.length ?? 0;
+  meta.innerHTML = `
+    <span>Ends ${formatDate(listing.endsAt)}</span>
+    <span><strong>${bidCount}</strong> bids</span>
+  `;
+  content.append(meta);
+
+  item.append(content);
+
+  return item;
+};
+
+const renderCollection = (container, items, emptyMessage) => {
+  if (!container) {
+    return;
+  }
+
+  container.innerHTML = "";
+
+  if (!items || !items.length) {
+    const empty = document.createElement("li");
+    empty.className = "listing-card listing-card--empty";
+    empty.textContent = emptyMessage;
+    container.append(empty);
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  items.forEach((item) => fragment.append(createListingItem(item)));
+  container.append(fragment);
+};
+
+const hydrateProfile = (profile, { updateTitle = true } = {}) => {
+  if (!profile) {
+    return;
+  }
+
+  assignText(nameElements, profile.name);
+  if (profile.name && updateTitle) {
+    document.title = `${profile.name} | Auction House`;
+  }
+  assignText(emailElements, profile.email);
+
+  const rawCredits = Number(profile.credits ?? 0);
+  const credits = Number.isFinite(rawCredits) ? rawCredits : 0;
+  const formattedCredits = new Intl.NumberFormat().format(credits);
+  assignText(creditElements, `${formattedCredits} credits`);
+
+  const listingCount =
+    profile._count?.listings ?? profile.listings?.length ?? 0;
+  const winCount = profile._count?.wins ?? profile.wins?.length ?? 0;
+
+  renderCount(listingCountElements, listingCount);
+  renderCount(winCountElements, winCount);
+
+  renderCollection(
+    listingsContainer,
+    profile.listings,
+    "No active listings yet.",
+  );
+  renderCollection(winsContainer, profile.wins, "No wins yet.");
+
+  if (auth?.name && auth.name === profile.name) {
+    setStoredAuth({ ...auth, credits });
+    emitAuthChanged();
+  }
+};
+
+const loadProfile = async () => {
+  if (!profileName) {
+    setStatus("Sign in to view your profile.", "warning");
+    hydrateProfile(fallbackProfile, { updateTitle: false });
+    return;
+  }
+
+  setStatus("Loading profile…", "info");
+
+  try {
+    const response = await getProfile(profileName, {
+      _listings: true,
+      _wins: true,
+    });
+
+    const profile = response?.data;
+
+    if (!profile) {
+      throw new Error("Profile not found");
+    }
+
+    setStatus("");
+    hydrateProfile(profile, { updateTitle: true });
+  } catch (error) {
+    console.error(error);
+    if (!auth?.accessToken) {
+      setStatus("Sign in to view your profile.", "warning");
+    } else {
+      setStatus(
+        error.message ||
+          "We couldn't load this profile right now. Showing an example instead.",
+        "error",
+      );
+    }
+    hydrateProfile(fallbackProfile, { updateTitle: false });
+  }
+};
+
+loadProfile();
 
 window.addEventListener("unload", () => {
   if (typeof teardown === "function") {

--- a/public/assets/js/register.js
+++ b/public/assets/js/register.js
@@ -1,36 +1,81 @@
+/* eslint-env browser */
+
+import { registerUser } from "./shared/api.js";
 import { initPageChrome } from "./shared/page.js";
 
 const teardown = initPageChrome();
 
 const form = document.querySelector("[data-register-form]");
 
-if (form) {
+const createStatusElement = () => {
   const status = document.createElement("p");
   status.className = "form__status";
   status.setAttribute("role", "status");
   status.setAttribute("aria-live", "polite");
   status.hidden = true;
+  return status;
+};
+
+const isValidNoroffEmail = (email) => /@(?:stud\.)?noroff\.no$/i.test(email);
+
+if (form) {
+  const status = createStatusElement();
   form.append(status);
 
-  form.addEventListener("submit", (event) => {
+  form.addEventListener("submit", async (event) => {
     event.preventDefault();
+
+    if (form.dataset.submitting === "true") {
+      return;
+    }
 
     const formData = new FormData(form);
     const name = String(formData.get("name") ?? "").trim();
     const email = String(formData.get("email") ?? "").trim();
     const password = String(formData.get("password") ?? "");
+    const venueManager = formData.get("venueManager") === "on";
 
     if (!name || !email || password.length < 8) {
       status.hidden = false;
       status.textContent =
-        "Please provide name, email and a password with at least 8 characters.";
+        "Provide a name, Noroff email, and a password with at least 8 characters.";
       status.className = "form__status form__status--error";
       return;
     }
 
-    status.hidden = false;
-    status.textContent = "Account created! You can now log in.";
-    status.className = "form__status form__status--success";
+    if (!isValidNoroffEmail(email)) {
+      status.hidden = false;
+      status.textContent =
+        "Use your @stud.noroff.no or @noroff.no email address.";
+      status.className = "form__status form__status--error";
+      return;
+    }
+
+    try {
+      form.dataset.submitting = "true";
+      status.hidden = false;
+      status.textContent = "Creating your account…";
+      status.className = "form__status";
+
+      await registerUser({
+        name,
+        email,
+        password,
+        venueManager,
+      });
+
+      status.textContent = "Account created! You can now log in.";
+      status.className = "form__status form__status--success";
+      form.reset();
+    } catch (error) {
+      console.error(error);
+      status.hidden = false;
+      status.textContent =
+        error.message || "Registration failed. Please try again.";
+      status.className = "form__status form__status--error";
+    } finally {
+      form.dataset.submitting = "false";
+    }
   });
 }
 

--- a/public/assets/js/shared/api.js
+++ b/public/assets/js/shared/api.js
@@ -1,0 +1,198 @@
+/* eslint-env browser */
+
+const API_BASE_URL = "https://v2.api.noroff.dev";
+const API_KEY = "ec37bd36-f4e0-48b8-915f-f96d6f959477";
+const STORAGE_KEY = "auction-house-auth";
+
+const readJSON = (value) => {
+  if (!value) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    console.warn("Unable to parse stored auth payload", error);
+    return undefined;
+  }
+};
+
+export const getStoredAuth = () => {
+  if (typeof localStorage === "undefined") {
+    return undefined;
+  }
+
+  return readJSON(localStorage.getItem(STORAGE_KEY));
+};
+
+export const setStoredAuth = (payload) => {
+  if (typeof localStorage === "undefined") {
+    return;
+  }
+
+  if (!payload) {
+    localStorage.removeItem(STORAGE_KEY);
+    return;
+  }
+
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+};
+
+export const clearStoredAuth = () => {
+  if (typeof localStorage === "undefined") {
+    return;
+  }
+
+  localStorage.removeItem(STORAGE_KEY);
+};
+
+const extractErrorMessage = async (response) => {
+  try {
+    const contentType = response.headers.get("content-type") || "";
+    if (!contentType.includes("application/json")) {
+      return response.statusText || "Request failed";
+    }
+
+    const body = await response.json();
+
+    if (body?.errors?.length) {
+      return body.errors.map((item) => item.message).join(". ");
+    }
+
+    if (body?.error?.message) {
+      return body.error.message;
+    }
+
+    if (body?.message) {
+      return body.message;
+    }
+
+    return response.statusText || "Request failed";
+  } catch {
+    return response.statusText || "Request failed";
+  }
+};
+
+const getToken = () => getStoredAuth()?.accessToken;
+
+export const request = async (
+  path,
+  { method = "GET", body, signal, headers = {}, requireAuth = false } = {},
+) => {
+  const token = getToken();
+
+  if (requireAuth && !token) {
+    throw new Error("You must be logged in to perform this action.");
+  }
+
+  const requestHeaders = new Headers({
+    "X-Noroff-API-Key": API_KEY,
+    ...headers,
+  });
+
+  if (body && !requestHeaders.has("Content-Type")) {
+    requestHeaders.set("Content-Type", "application/json");
+  }
+
+  if (token) {
+    requestHeaders.set("Authorization", `Bearer ${token}`);
+  }
+
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method,
+    body: body ? JSON.stringify(body) : undefined,
+    headers: requestHeaders,
+    signal,
+  });
+
+  if (!response.ok) {
+    const message = await extractErrorMessage(response);
+    throw new Error(message || "Request failed");
+  }
+
+  if (response.status === 204) {
+    return undefined;
+  }
+
+  const contentType = response.headers.get("content-type") || "";
+  if (!contentType.includes("application/json")) {
+    return undefined;
+  }
+
+  return response.json();
+};
+
+const buildQuery = (params) => {
+  if (!params) {
+    return "";
+  }
+
+  if (typeof params === "string") {
+    return params.startsWith("?") ? params : `?${params}`;
+  }
+
+  const searchParams = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === "") {
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      value.forEach((item) => searchParams.append(key, item));
+      return;
+    }
+
+    searchParams.set(key, value);
+  });
+
+  const queryString = searchParams.toString();
+  return queryString ? `?${queryString}` : "";
+};
+
+export const registerUser = (payload) =>
+  request("/auth/register", {
+    method: "POST",
+    body: payload,
+    requireAuth: false,
+  });
+
+export const loginUser = (payload) =>
+  request("/auth/login", { method: "POST", body: payload, requireAuth: false });
+
+export const getListings = (params) =>
+  request(`/auction/listings${buildQuery(params)}`, { requireAuth: false });
+
+export const searchListings = (query, params) => {
+  const queryString =
+    typeof params === "string" || !params ? params : { ...params };
+  const suffix = buildQuery(queryString);
+  const connector = suffix ? `&${suffix.replace(/^[?&]/, "")}` : "";
+  return request(
+    `/auction/listings/search?q=${encodeURIComponent(query)}${connector}`,
+    {
+      requireAuth: false,
+    },
+  );
+};
+
+export const getListing = (id, params) =>
+  request(`/auction/listings/${encodeURIComponent(id)}${buildQuery(params)}`, {
+    requireAuth: false,
+  });
+
+export const getProfile = (name, params) =>
+  request(`/auction/profiles/${encodeURIComponent(name)}${buildQuery(params)}`);
+
+export const getProfileListings = (name, params) =>
+  request(
+    `/auction/profiles/${encodeURIComponent(name)}/listings${buildQuery(params)}`,
+  );
+
+export const getProfileWins = (name, params) =>
+  request(
+    `/auction/profiles/${encodeURIComponent(name)}/wins${buildQuery(params)}`,
+  );
+
+export const emitAuthChanged = () => {
+  window.dispatchEvent(new CustomEvent("auth:changed"));
+};

--- a/public/assets/js/shared/data.js
+++ b/public/assets/js/shared/data.js
@@ -1,40 +1,44 @@
-export const listingSeedData = [
+export const fallbackListings = [
   {
-    id: "assignment-1",
-    title: "Sprint planning workshop",
+    id: "sample-1",
+    title: "Hand-painted cat portrait",
     description:
-      "Coordinate roles, deadlines and deliverables for the upcoming sprint.",
-    category: "event",
-    deadline: new Date().setDate(new Date().getDate() + 7),
-    status: "Scheduled",
-    owner: "Product team",
+      "A cheerful study in gouache ready to brighten any reading nook.",
+    media: [
+      {
+        url: "https://images.unsplash.com/photo-1518791841217-8f162f1e1131?auto=format&fit=crop&w=800&q=80",
+        alt: "Cat portrait",
+      },
+    ],
+    endsAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 3).toISOString(),
+    _count: { bids: 2 },
+    seller: { name: "Sample seller" },
   },
   {
-    id: "resource-2",
-    title: "Design system refresh",
-    description: "Update spacing, typography tokens and component guidelines.",
-    category: "resource",
-    deadline: new Date().setDate(new Date().getDate() + 14),
-    status: "In progress",
-    owner: "Design ops",
-  },
-  {
-    id: "assignment-3",
-    title: "Usability testing report",
+    id: "sample-2",
+    title: "Vintage brass collar",
     description:
-      "Summarise feedback from test participants and prioritise fixes.",
-    category: "assignment",
-    deadline: new Date().setDate(new Date().getDate() + 21),
-    status: "Awaiting review",
-    owner: "Research team",
+      "Soft velvet lining with tiny bells collected from a Parisian market.",
+    media: [
+      {
+        url: "https://images.unsplash.com/photo-1543852786-1cf6624b9987?auto=format&fit=crop&w=800&q=80",
+        alt: "Brass collar",
+      },
+    ],
+    endsAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 7).toISOString(),
+    _count: { bids: 5 },
+    seller: { name: "Sample seller" },
   },
 ];
 
-export const profileSeedData = {
-  name: "Avery Johnson",
-  email: "avery.johnson@example.com",
-  stats: {
-    active: 3,
-    completed: 8,
+export const fallbackProfile = {
+  name: "Sample Seller",
+  email: "sample.seller@stud.noroff.no",
+  credits: 0,
+  listings: fallbackListings,
+  wins: [],
+  _count: {
+    listings: fallbackListings.length,
+    wins: 0,
   },
 };

--- a/public/assets/js/shared/page.js
+++ b/public/assets/js/shared/page.js
@@ -1,23 +1,6 @@
-const prefersDarkScheme = window.matchMedia("(prefers-color-scheme: dark)");
+/* eslint-env browser */
 
-const syncThemeWithPreference = () => {
-  document.body.classList.toggle("theme--dark", prefersDarkScheme.matches);
-};
-
-const registerThemeListeners = () => {
-  if (typeof prefersDarkScheme.addEventListener === "function") {
-    prefersDarkScheme.addEventListener("change", syncThemeWithPreference);
-    return () =>
-      prefersDarkScheme.removeEventListener("change", syncThemeWithPreference);
-  }
-
-  if (typeof prefersDarkScheme.addListener === "function") {
-    prefersDarkScheme.addListener(syncThemeWithPreference);
-    return () => prefersDarkScheme.removeListener(syncThemeWithPreference);
-  }
-
-  return undefined;
-};
+import { clearStoredAuth, emitAuthChanged, getStoredAuth } from "./api.js";
 
 const updateCurrentYear = () => {
   const yearElement = document.querySelector("[data-year]");
@@ -27,24 +10,118 @@ const updateCurrentYear = () => {
   }
 };
 
-export const initPageChrome = () => {
-  syncThemeWithPreference();
-  const unregister = registerThemeListeners();
-  updateCurrentYear();
+const toggleElements = (selector, shouldShow) => {
+  document.querySelectorAll(selector).forEach((element) => {
+    element.hidden = !shouldShow;
+  });
+};
+
+const updateProfileLinks = (auth) => {
+  const profileLinks = document.querySelectorAll("[data-profile-link]");
+
+  profileLinks.forEach((link) => {
+    const href = link.getAttribute("href") || "./profile.html";
+    const url = new URL(href, window.location.origin);
+
+    if (auth?.name) {
+      url.searchParams.set("name", auth.name);
+    } else {
+      url.searchParams.delete("name");
+    }
+
+    link.setAttribute("href", `${url.pathname}${url.search}${url.hash}`);
+  });
+};
+
+const updateUserBadges = (auth) => {
+  const nameElements = document.querySelectorAll("[data-user-name]");
+  nameElements.forEach((element) => {
+    element.textContent = auth?.name ?? "";
+  });
+
+  const creditElements = document.querySelectorAll("[data-user-credits]");
+  if (creditElements.length) {
+    const credits = auth?.credits;
+    const formatted =
+      typeof credits === "number"
+        ? new Intl.NumberFormat().format(credits)
+        : "";
+
+    creditElements.forEach((element) => {
+      if (formatted) {
+        element.textContent = `${formatted} credits`;
+        element.hidden = false;
+      } else {
+        element.textContent = "";
+        element.hidden = true;
+      }
+    });
+  }
+};
+
+const updateAuthUI = () => {
+  const auth = getStoredAuth();
+  const signedIn = Boolean(auth?.accessToken);
+
+  toggleElements('[data-auth="signed-in"]', signedIn);
+  toggleElements('[data-auth="signed-out"]', !signedIn);
+  updateProfileLinks(auth);
+  updateUserBadges(auth);
+};
+
+const bindLogoutButtons = () => {
+  const buttons = Array.from(document.querySelectorAll("[data-logout]"));
+
+  const handleClick = (event) => {
+    event.preventDefault();
+    clearStoredAuth();
+    emitAuthChanged();
+  };
+
+  buttons.forEach((button) => button.addEventListener("click", handleClick));
 
   return () => {
-    if (typeof unregister === "function") {
-      unregister();
-    }
+    buttons.forEach((button) =>
+      button.removeEventListener("click", handleClick),
+    );
   };
 };
 
-export const renderCount = (element, count) => {
-  if (!element) {
+export const initPageChrome = () => {
+  updateCurrentYear();
+  updateAuthUI();
+  const unbindLogout = bindLogoutButtons();
+
+  const handleAuthChanged = () => {
+    updateAuthUI();
+  };
+
+  window.addEventListener("auth:changed", handleAuthChanged);
+
+  return () => {
+    window.removeEventListener("auth:changed", handleAuthChanged);
+    unbindLogout();
+  };
+};
+
+export const renderCount = (target, count) => {
+  if (!target) {
     return;
   }
 
-  element.textContent = new Intl.NumberFormat().format(count);
+  const formatted = new Intl.NumberFormat().format(count);
+  const assign = (element) => {
+    if (element) {
+      element.textContent = formatted;
+    }
+  };
+
+  if (typeof target.forEach === "function" && !target.nodeType) {
+    target.forEach(assign);
+    return;
+  }
+
+  assign(target);
 };
 
 export const formatDate = (value) => {
@@ -62,5 +139,7 @@ export const formatDate = (value) => {
     year: "numeric",
     month: "short",
     day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
   }).format(date);
 };

--- a/public/index.html
+++ b/public/index.html
@@ -3,68 +3,93 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Semester Project 2</title>
+    <title>Auction House | Semester Project 2</title>
     <link rel="stylesheet" href="./assets/css/style.css" />
   </head>
-  <body class="page page--landing">
-    <header class="page__header">
-      <div class="page__header-inner">
-        <h1>Semester Project 2</h1>
-        <p>
-          An interactive dashboard for tracking course milestones and
-          deliverables.
-        </p>
+  <body>
+    <header class="site-header">
+      <div class="wrapper site-header__inner">
+        <a class="brand" href="./index.html">Auction House</a>
+        <nav class="site-nav" aria-label="Main navigation">
+          <ul class="site-nav__list">
+            <li>
+              <a class="site-nav__link" href="./index.html" aria-current="page"
+                >Home</a
+              >
+            </li>
+            <li>
+              <a class="site-nav__link" href="./allListing.html">Listings</a>
+            </li>
+            <li data-auth="signed-in" hidden>
+              <span class="badge" data-user-credits></span>
+            </li>
+            <li data-auth="signed-in" hidden>
+              <span class="site-nav__user"
+                >Hi, <strong data-user-name></strong
+              ></span>
+            </li>
+            <li data-auth="signed-in" hidden>
+              <a class="site-nav__link" href="./profile.html" data-profile-link
+                >My profile</a
+              >
+            </li>
+            <li data-auth="signed-out">
+              <a class="site-nav__link" href="./register.html">Register</a>
+            </li>
+            <li data-auth="signed-out">
+              <a class="site-nav__link" href="./login.html">Log in</a>
+            </li>
+            <li data-auth="signed-in" hidden>
+              <button class="site-nav__button" type="button" data-logout>
+                Log out
+              </button>
+            </li>
+          </ul>
+        </nav>
       </div>
     </header>
 
-    <nav class="page__nav" aria-label="Main navigation">
-      <ul class="page__nav-list">
-        <li><a href="./index.html" aria-current="page">Home</a></li>
-        <li><a href="./login.html">Log in</a></li>
-        <li><a href="./register.html">Register</a></li>
-        <li><a href="./allListing.html">All listings</a></li>
-        <li><a href="./profile.html">Profile</a></li>
-      </ul>
-    </nav>
-
-    <main class="page__main">
-      <section class="card">
-        <h2>Project Overview</h2>
-        <p>
-          Semester Project 2 consolidates course milestones into a single
-          dashboard that helps you follow deadlines, track dependencies, and
-          collaborate with teammates in real time.
+    <main class="wrapper stack">
+      <section class="hero-card">
+        <h1 class="page-title">Find your next auction</h1>
+        <p class="page-lede">
+          Search across every listing to discover something new or jump back to
+          your favourite sellers.
         </p>
-        <ul>
-          <li>Visualise milestones on a timeline to understand sequencing.</li>
-          <li>Assign owners and statuses so responsibilities stay clear.</li>
-          <li>Receive reminders before critical deliverables are due.</li>
-        </ul>
+        <form class="search-form" action="./allListing.html" method="get">
+          <div class="search-form__fields">
+            <input type="search" name="query" placeholder="Search listings" />
+            <button type="submit" class="button">Search</button>
+          </div>
+        </form>
+        <div class="topics" aria-label="Popular search topics">
+          <span class="topic-pill">Collars</span>
+          <span class="topic-pill">Portraits</span>
+          <span class="topic-pill">Toys</span>
+          <span class="topic-pill">Accessories</span>
+          <span class="topic-pill">Beds</span>
+        </div>
       </section>
 
-      <section class="card">
-        <h2>Core Features</h2>
-        <ul class="pill-list">
-          <li>Milestone timeline</li>
-          <li>Team assignments</li>
-          <li>Progress tracking</li>
-          <li>Automated reminders</li>
-          <li>Exportable reports</li>
-        </ul>
-      </section>
-
-      <section class="card">
-        <h2>Getting Started</h2>
+      <section class="section">
+        <h2>New to Auction House?</h2>
         <p>
-          Begin by entering your course schedule, then invite teammates so
-          everyone can contribute to the plan. Use the built-in templates to
-          jump-start milestone planning and track submissions all semester long.
+          Register with your Noroff email, list an item in minutes, and keep
+          track of bids from any device.
         </p>
+        <div class="section__actions">
+          <a class="button" href="./register.html">Create an account</a>
+          <a class="button button--outline" href="./allListing.html"
+            >Browse listings</a
+          >
+        </div>
       </section>
     </main>
 
-    <footer class="page__footer">
-      &copy; <span data-year></span> Semester Project 2 Team
+    <footer class="site-footer">
+      <div class="wrapper site-footer__inner">
+        <p>&copy; <span data-year></span> Auction House</p>
+      </div>
     </footer>
 
     <script type="module" src="./assets/js/index.js"></script>

--- a/public/listing.html
+++ b/public/listing.html
@@ -3,54 +3,85 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Listing details | Semester Project 2</title>
+    <title>Listing details | Auction House</title>
     <link rel="stylesheet" href="./assets/css/style.css" />
   </head>
-  <body class="page page--listing">
-    <header class="page__header">
-      <div class="page__header-inner">
-        <h1>Listing details</h1>
-        <p>Review everything you need to know about this listing.</p>
+  <body>
+    <header class="site-header">
+      <div class="wrapper site-header__inner">
+        <a class="brand" href="./index.html">Auction House</a>
+        <nav class="site-nav" aria-label="Main navigation">
+          <ul class="site-nav__list">
+            <li><a class="site-nav__link" href="./index.html">Home</a></li>
+            <li>
+              <a class="site-nav__link" href="./allListing.html">Listings</a>
+            </li>
+            <li data-auth="signed-in" hidden>
+              <span class="badge" data-user-credits></span>
+            </li>
+            <li data-auth="signed-in" hidden>
+              <span class="site-nav__user"
+                >Hi, <strong data-user-name></strong
+              ></span>
+            </li>
+            <li data-auth="signed-in" hidden>
+              <a
+                class="site-nav__link"
+                href="./profile.html"
+                data-profile-link
+                aria-current="page"
+                >My profile</a
+              >
+            </li>
+            <li data-auth="signed-out">
+              <a class="site-nav__link" href="./register.html">Register</a>
+            </li>
+            <li data-auth="signed-out">
+              <a class="site-nav__link" href="./login.html">Log in</a>
+            </li>
+            <li data-auth="signed-in" hidden>
+              <button class="site-nav__button" type="button" data-logout>
+                Log out
+              </button>
+            </li>
+          </ul>
+        </nav>
       </div>
     </header>
 
-    <nav class="page__nav" aria-label="Main navigation">
-      <ul class="page__nav-list">
-        <li><a href="./index.html">Home</a></li>
-        <li><a href="./login.html">Log in</a></li>
-        <li><a href="./register.html">Register</a></li>
-        <li><a href="./allListing.html">All listings</a></li>
-        <li><a href="./profile.html">Profile</a></li>
-      </ul>
-    </nav>
+    <main class="wrapper stack">
+      <section class="hero-card hero-card--listing">
+        <figure class="hero-card__media">
+          <img data-listing-image alt="" hidden />
+        </figure>
+        <div class="hero-card__body">
+          <p class="eyebrow">Listing</p>
+          <h1 data-listing-title>Loading…</h1>
+          <p data-listing-description>Loading description…</p>
+          <div class="listing-card__meta listing-card__meta--stack">
+            <span>Seller: <strong data-listing-seller>Loading…</strong></span>
+            <span>Ends <time data-listing-deadline>Loading…</time></span>
+            <span><strong data-listing-bid-count>0</strong> bids</span>
+          </div>
+          <p class="section__status" data-listing-status hidden></p>
+          <div class="section__actions">
+            <a class="button button--outline" href="./allListing.html"
+              >Back to listings</a
+            >
+          </div>
+        </div>
+      </section>
 
-    <main class="page__main">
-      <article class="card" data-listing-detail>
-        <header class="card__header">
-          <p class="card__meta" data-listing-status>Loading status…</p>
-          <h2 data-listing-title>Loading title…</h2>
-        </header>
-        <p data-listing-description>Loading description…</p>
-
-        <dl class="definition-list">
-          <div>
-            <dt>Owner</dt>
-            <dd data-listing-owner>Loading owner…</dd>
-          </div>
-          <div>
-            <dt>Deadline</dt>
-            <dd data-listing-deadline>Loading deadline…</dd>
-          </div>
-          <div>
-            <dt>Category</dt>
-            <dd data-listing-category>Loading category…</dd>
-          </div>
-        </dl>
-      </article>
+      <section class="section">
+        <h2>Recent bids</h2>
+        <ul class="listing-bids" data-bid-list></ul>
+      </section>
     </main>
 
-    <footer class="page__footer">
-      &copy; <span data-year></span> Semester Project 2 Team
+    <footer class="site-footer">
+      <div class="wrapper site-footer__inner">
+        <p>&copy; <span data-year></span> Auction House</p>
+      </div>
     </footer>
 
     <script type="module" src="./assets/js/listing.js"></script>

--- a/public/login.html
+++ b/public/login.html
@@ -3,36 +3,60 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Log in | Semester Project 2</title>
+    <title>Log in | Auction House</title>
     <link rel="stylesheet" href="./assets/css/style.css" />
   </head>
-  <body class="page page--auth">
-    <header class="page__header">
-      <div class="page__header-inner">
-        <h1>Welcome back</h1>
-        <p>Sign in to manage your listings and track your progress.</p>
+  <body>
+    <header class="site-header">
+      <div class="wrapper site-header__inner">
+        <a class="brand" href="./index.html">Auction House</a>
+        <nav class="site-nav" aria-label="Main navigation">
+          <ul class="site-nav__list">
+            <li><a class="site-nav__link" href="./index.html">Home</a></li>
+            <li>
+              <a class="site-nav__link" href="./allListing.html">Listings</a>
+            </li>
+            <li data-auth="signed-in" hidden>
+              <span class="badge" data-user-credits></span>
+            </li>
+            <li data-auth="signed-in" hidden>
+              <span class="site-nav__user"
+                >Hi, <strong data-user-name></strong
+              ></span>
+            </li>
+            <li data-auth="signed-in" hidden>
+              <a class="site-nav__link" href="./profile.html" data-profile-link
+                >My profile</a
+              >
+            </li>
+            <li data-auth="signed-out">
+              <a class="site-nav__link" href="./register.html">Register</a>
+            </li>
+            <li data-auth="signed-out">
+              <a class="site-nav__link" href="./login.html" aria-current="page"
+                >Log in</a
+              >
+            </li>
+            <li data-auth="signed-in" hidden>
+              <button class="site-nav__button" type="button" data-logout>
+                Log out
+              </button>
+            </li>
+          </ul>
+        </nav>
       </div>
     </header>
 
-    <nav class="page__nav" aria-label="Main navigation">
-      <ul class="page__nav-list">
-        <li><a href="./index.html">Home</a></li>
-        <li><a href="./login.html" aria-current="page">Log in</a></li>
-        <li><a href="./register.html">Register</a></li>
-        <li><a href="./allListing.html">All listings</a></li>
-        <li><a href="./profile.html">Profile</a></li>
-      </ul>
-    </nav>
-
-    <main class="page__main">
-      <section class="card card--form">
-        <h2>Log in to your account</h2>
+    <main class="wrapper stack">
+      <section class="hero-card hero-card--left">
+        <h1>Log in</h1>
+        <p>Enter your Noroff email and password to continue.</p>
         <form class="form" data-auth-form>
-          <label class="form__field">
+          <label>
             <span>Email</span>
             <input type="email" name="email" autocomplete="email" required />
           </label>
-          <label class="form__field">
+          <label>
             <span>Password</span>
             <input
               type="password"
@@ -41,13 +65,15 @@
               required
             />
           </label>
-          <button type="submit" class="button">Continue</button>
+          <button type="submit" class="button">Log in</button>
         </form>
       </section>
     </main>
 
-    <footer class="page__footer">
-      &copy; <span data-year></span> Semester Project 2 Team
+    <footer class="site-footer">
+      <div class="wrapper site-footer__inner">
+        <p>&copy; <span data-year></span> Auction House</p>
+      </div>
     </footer>
 
     <script type="module" src="./assets/js/login.js"></script>

--- a/public/profile.html
+++ b/public/profile.html
@@ -3,57 +3,85 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Profile | Semester Project 2</title>
+    <title>Profile | Auction House</title>
     <link rel="stylesheet" href="./assets/css/style.css" />
   </head>
-  <body class="page page--profile">
-    <header class="page__header">
-      <div class="page__header-inner">
-        <h1>Your profile</h1>
-        <p>Manage your personal information and account preferences.</p>
+  <body>
+    <header class="site-header">
+      <div class="wrapper site-header__inner">
+        <a class="brand" href="./index.html">Auction House</a>
+        <nav class="site-nav" aria-label="Main navigation">
+          <ul class="site-nav__list">
+            <li><a class="site-nav__link" href="./index.html">Home</a></li>
+            <li>
+              <a class="site-nav__link" href="./allListing.html">Listings</a>
+            </li>
+            <li data-auth="signed-in" hidden>
+              <span class="badge" data-user-credits></span>
+            </li>
+            <li data-auth="signed-in" hidden>
+              <span class="site-nav__user"
+                >Hi, <strong data-user-name></strong
+              ></span>
+            </li>
+            <li data-auth="signed-in" hidden>
+              <a
+                class="site-nav__link"
+                href="./profile.html"
+                data-profile-link
+                aria-current="page"
+                >My profile</a
+              >
+            </li>
+            <li data-auth="signed-out">
+              <a class="site-nav__link" href="./register.html">Register</a>
+            </li>
+            <li data-auth="signed-out">
+              <a class="site-nav__link" href="./login.html">Log in</a>
+            </li>
+            <li data-auth="signed-in" hidden>
+              <button class="site-nav__button" type="button" data-logout>
+                Log out
+              </button>
+            </li>
+          </ul>
+        </nav>
       </div>
     </header>
 
-    <nav class="page__nav" aria-label="Main navigation">
-      <ul class="page__nav-list">
-        <li><a href="./index.html">Home</a></li>
-        <li><a href="./login.html">Log in</a></li>
-        <li><a href="./register.html">Register</a></li>
-        <li><a href="./allListing.html">All listings</a></li>
-        <li><a href="./profile.html" aria-current="page">Profile</a></li>
-      </ul>
-    </nav>
-
-    <main class="page__main">
-      <section class="card" data-profile-summary>
-        <header class="card__header">
-          <h2>Profile summary</h2>
-        </header>
-        <dl class="definition-list">
-          <div>
-            <dt>Name</dt>
-            <dd data-profile-name>Loading…</dd>
-          </div>
-          <div>
-            <dt>Email</dt>
-            <dd data-profile-email>Loading…</dd>
-          </div>
-        </dl>
+    <main class="wrapper stack">
+      <section class="hero-card hero-card--left">
+        <h1 data-profile-name>Loading…</h1>
+        <p>Email: <span data-profile-email>Loading…</span></p>
+        <p class="profile__credits" data-profile-credits>0 credits</p>
+        <p class="section__status" data-profile-status hidden></p>
       </section>
 
-      <section class="card" data-profile-stats>
-        <header class="card__header">
-          <h2>Activity</h2>
-        </header>
-        <ul class="pill-list">
-          <li><span data-profile-active>0</span> active listings</li>
-          <li><span data-profile-completed>0</span> completed listings</li>
-        </ul>
+      <section class="section">
+        <div class="section__header">
+          <h2>Active listings</h2>
+          <p class="section__status">
+            <span data-profile-listing-count>0</span> live
+          </p>
+        </div>
+        <ul class="listing-list" data-profile-listings></ul>
+      </section>
+
+      <section class="section">
+        <div class="section__header">
+          <h2>Wins</h2>
+          <p class="section__status">
+            <span data-profile-win-count>0</span> won
+          </p>
+        </div>
+        <ul class="listing-list" data-profile-wins></ul>
       </section>
     </main>
 
-    <footer class="page__footer">
-      &copy; <span data-year></span> Semester Project 2 Team
+    <footer class="site-footer">
+      <div class="wrapper site-footer__inner">
+        <p>&copy; <span data-year></span> Auction House</p>
+      </div>
     </footer>
 
     <script type="module" src="./assets/js/profile.js"></script>

--- a/public/register.html
+++ b/public/register.html
@@ -3,57 +3,92 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Register | Semester Project 2</title>
+    <title>Register | Auction House</title>
     <link rel="stylesheet" href="./assets/css/style.css" />
   </head>
-  <body class="page page--auth">
-    <header class="page__header">
-      <div class="page__header-inner">
-        <h1>Create your account</h1>
-        <p>
-          Join the platform to publish listings and collaborate with your team.
-        </p>
+  <body>
+    <header class="site-header">
+      <div class="wrapper site-header__inner">
+        <a class="brand" href="./index.html">Auction House</a>
+        <nav class="site-nav" aria-label="Main navigation">
+          <ul class="site-nav__list">
+            <li><a class="site-nav__link" href="./index.html">Home</a></li>
+            <li>
+              <a class="site-nav__link" href="./allListing.html">Listings</a>
+            </li>
+            <li data-auth="signed-in" hidden>
+              <span class="badge" data-user-credits></span>
+            </li>
+            <li data-auth="signed-in" hidden>
+              <span class="site-nav__user"
+                >Hi, <strong data-user-name></strong
+              ></span>
+            </li>
+            <li data-auth="signed-in" hidden>
+              <a class="site-nav__link" href="./profile.html" data-profile-link
+                >My profile</a
+              >
+            </li>
+            <li data-auth="signed-out">
+              <a
+                class="site-nav__link"
+                href="./register.html"
+                aria-current="page"
+                >Register</a
+              >
+            </li>
+            <li data-auth="signed-out">
+              <a class="site-nav__link" href="./login.html">Log in</a>
+            </li>
+            <li data-auth="signed-in" hidden>
+              <button class="site-nav__button" type="button" data-logout>
+                Log out
+              </button>
+            </li>
+          </ul>
+        </nav>
       </div>
     </header>
 
-    <nav class="page__nav" aria-label="Main navigation">
-      <ul class="page__nav-list">
-        <li><a href="./index.html">Home</a></li>
-        <li><a href="./login.html">Log in</a></li>
-        <li><a href="./register.html" aria-current="page">Register</a></li>
-        <li><a href="./allListing.html">All listings</a></li>
-        <li><a href="./profile.html">Profile</a></li>
-      </ul>
-    </nav>
-
-    <main class="page__main">
-      <section class="card card--form">
-        <h2>Start for free</h2>
+    <main class="wrapper stack">
+      <section class="hero-card hero-card--left">
+        <h1>Create an account</h1>
+        <p>
+          Use your Noroff email address and a password with at least 8
+          characters.
+        </p>
         <form class="form" data-register-form>
-          <label class="form__field">
+          <label>
             <span>Name</span>
             <input type="text" name="name" autocomplete="name" required />
           </label>
-          <label class="form__field">
+          <label>
             <span>Email</span>
             <input type="email" name="email" autocomplete="email" required />
           </label>
-          <label class="form__field">
+          <label>
             <span>Password</span>
             <input
               type="password"
               name="password"
               autocomplete="new-password"
+              minlength="8"
               required
             />
           </label>
-          <button type="submit" class="button">Create account</button>
+          <label class="form__checkbox">
+            <input type="checkbox" name="venueManager" />
+            <span>I want to manage venues</span>
+          </label>
+          <button type="submit" class="button">Register</button>
         </form>
       </section>
     </main>
 
-    <footer class="page__footer">
-      &copy; <span data-year></span> Semester Project 2 Team
+    <footer class="site-footer">
+      <div class="wrapper site-footer__inner">
+        <p>&copy; <span data-year></span> Auction House</p>
+      </div>
     </footer>
 
     <script type="module" src="./assets/js/register.js"></script>

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -2,298 +2,75 @@
 @tailwind components;
 @tailwind utilities;
 
+/*
+  This Tailwind source mirrors the lightweight styles defined in
+  public/assets/css/style.css so future builds remain consistent.
+*/
+
 @layer base {
-  :root {
-    color-scheme: light dark;
-    font-family: "Inter", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-    line-height: 1.6;
-    background-color: #f5f5f5;
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  html,
+  body {
+    margin: 0;
+    padding: 0;
   }
 
   body {
-    margin: 0;
-    background: linear-gradient(180deg, #f5f5f5 0%, #ffffff 35%);
-    color: #1a1a1a;
     min-height: 100vh;
+    font-family:
+      "Inter",
+      "Segoe UI",
+      -apple-system,
+      BlinkMacSystemFont,
+      sans-serif;
+    background-color: #f4f4f5;
+    color: #1f2933;
+    line-height: 1.6;
   }
 
-  body.theme--dark {
-    background: linear-gradient(180deg, #111827 0%, #1f2937 40%);
-    color: #f9fafb;
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  img {
+    max-width: 100%;
+    display: block;
   }
 }
 
 @layer components {
-  .page {
-    display: flex;
-    flex-direction: column;
-    min-height: 100vh;
+  .wrapper {
+    width: min(960px, 100%);
+    margin-left: auto;
+    margin-right: auto;
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
   }
 
-  .page__header {
-    background: rgba(22, 101, 216, 0.9);
-    color: #fff;
-    padding: clamp(2rem, 5vw, 3.5rem) 1rem;
-    text-align: center;
-    position: relative;
-    overflow: hidden;
+  .site-header {
+    @apply w-full border-b border-gray-200 bg-white;
   }
 
-  .page__header::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background:
-      radial-gradient(
-        circle at 20% 20%,
-        rgba(255, 255, 255, 0.25),
-        transparent 55%
-      ),
-      radial-gradient(
-        circle at 80% 20%,
-        rgba(255, 255, 255, 0.15),
-        transparent 60%
-      );
-    pointer-events: none;
-  }
-
-  .page__header-inner {
-    position: relative;
-    z-index: 1;
-    max-width: 48rem;
-    margin: 0 auto;
-  }
-
-  .page__nav {
-    background: rgba(255, 255, 255, 0.95);
-    backdrop-filter: blur(8px);
-    border-bottom: 1px solid rgba(15, 23, 42, 0.08);
-  }
-
-  .theme--dark .page__nav {
-    background: rgba(15, 23, 42, 0.85);
-    border-bottom-color: rgba(148, 163, 184, 0.25);
-  }
-
-  .page__nav-list {
-    display: flex;
-    justify-content: center;
-    gap: 1rem;
-    padding: 0.75rem 1rem;
-    margin: 0 auto;
-    list-style: none;
-    max-width: 60rem;
-  }
-
-  .page__nav-list a {
-    color: inherit;
-    text-decoration: none;
-    font-weight: 500;
-    padding: 0.25rem 0.75rem;
-    border-radius: 999px;
-    transition:
-      background-color 150ms ease,
-      color 150ms ease;
-  }
-
-  .page__nav-list a:hover,
-  .page__nav-list a:focus {
-    background: rgba(37, 99, 235, 0.1);
-    color: rgba(37, 99, 235, 1);
-  }
-
-  .page__nav-list a[aria-current="page"] {
-    background: rgba(37, 99, 235, 0.15);
-    color: rgba(37, 99, 235, 1);
-  }
-
-  .theme--dark .page__nav-list a:hover,
-  .theme--dark .page__nav-list a:focus,
-  .theme--dark .page__nav-list a[aria-current="page"] {
-    background: rgba(191, 219, 254, 0.16);
-    color: rgba(191, 219, 254, 1);
-  }
-
-  .page__main {
-    flex: 1;
-    max-width: 60rem;
-    width: min(90vw, 60rem);
-    margin: -2rem auto 3rem;
-    padding: 0;
-    display: grid;
-    gap: 1.5rem;
-  }
-
-  .card {
-    background: #fff;
-    border-radius: 1.25rem;
-    padding: clamp(1.5rem, 4vw, 2.5rem);
-    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.1);
-  }
-
-  .theme--dark .card {
-    background: rgba(15, 23, 42, 0.85);
-    box-shadow: 0 20px 45px rgba(2, 6, 23, 0.4);
-  }
-
-  .card__header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-end;
-    gap: 1rem;
-    margin-bottom: 1rem;
-  }
-
-  .card__meta {
-    color: rgba(15, 23, 42, 0.6);
-    font-size: 0.95rem;
-  }
-
-  .theme--dark .card__meta {
-    color: rgba(226, 232, 240, 0.7);
-  }
-
-  .pill-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    list-style: none;
-    padding: 0;
-    margin: 0;
-  }
-
-  .pill-list li {
-    background: rgba(37, 99, 235, 0.1);
-    color: rgba(37, 99, 235, 1);
-    padding: 0.4rem 0.85rem;
-    border-radius: 999px;
-    font-size: 0.95rem;
-  }
-
-  .theme--dark .pill-list li {
-    background: rgba(191, 219, 254, 0.16);
-    color: rgba(191, 219, 254, 1);
-  }
-
-  .card--form {
-    max-width: 32rem;
-    margin: 0 auto;
-  }
-
-  .form {
-    display: grid;
-    gap: 1rem;
-    margin-top: 1.5rem;
-  }
-
-  .form__field {
-    display: grid;
-    gap: 0.5rem;
-    font-weight: 500;
-  }
-
-  .form__field input,
-  .form__field select {
+  .hero-card,
+  .section,
+  .listing-card {
+    @apply border border-gray-200 bg-white;
     border-radius: 0.75rem;
-    border: 1px solid rgba(15, 23, 42, 0.12);
-    padding: 0.75rem 1rem;
-    font-size: 1rem;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
   }
 
-  .form__field input:focus,
-  .form__field select:focus {
-    outline: 2px solid rgba(37, 99, 235, 0.4);
-    outline-offset: 2px;
+  .hero-card,
+  .section {
+    padding: 1.5rem;
   }
 
-  .form__status {
-    font-size: 0.95rem;
-    margin-top: 0.25rem;
-  }
-
-  .form__status--error {
-    color: #dc2626;
-  }
-
-  .form__status--success {
-    color: #16a34a;
-  }
-
-  .button {
-    border: none;
-    border-radius: 999px;
-    padding: 0.75rem 1.5rem;
-    font-size: 1rem;
-    font-weight: 600;
-    color: #fff;
-    background: linear-gradient(90deg, #2563eb, #7c3aed);
-    cursor: pointer;
-    transition:
-      transform 150ms ease,
-      box-shadow 150ms ease;
-  }
-
-  .button:hover,
-  .button:focus {
-    transform: translateY(-1px);
-    box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
-  }
-
-  .listing-grid {
-    display: grid;
-    gap: 1rem;
-    margin: 0;
-    padding: 0;
-    list-style: none;
-  }
-
-  .listing-grid li {
-    border-radius: 1rem;
-    border: 1px solid rgba(15, 23, 42, 0.08);
-    padding: 1.25rem;
-  }
-
-  .definition-list {
-    display: grid;
-    gap: 1rem;
-  }
-
-  .definition-list div {
-    display: grid;
-    gap: 0.25rem;
-  }
-
-  .definition-list dt {
-    font-size: 0.875rem;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: rgba(15, 23, 42, 0.6);
-  }
-
-  .definition-list dd {
-    margin: 0;
-    font-size: 1.05rem;
-    font-weight: 600;
-  }
-
-  .page__footer {
-    text-align: center;
-    padding: 2rem 1rem 3rem;
-    color: rgba(15, 23, 42, 0.6);
-  }
-
-  .theme--dark .page__footer {
-    color: rgba(226, 232, 240, 0.7);
-  }
-
-  @media (max-width: 48rem) {
-    .card__header {
-      flex-direction: column;
-      align-items: flex-start;
-    }
-
-    .page__nav-list {
-      flex-wrap: wrap;
-    }
+  .listing-card {
+    padding: 1rem;
   }
 }


### PR DESCRIPTION
## Summary
- replace the public page headers and sections with the compact "version 1" markup
- rewrite the shared stylesheet for a minimal gray-and-white layout with simple buttons and cards
- align the Tailwind source with the new lightweight component styles

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e7c072ac9c8321adc7b985e16d4ed3