### PR TITLE
Add bidding support and paginated listings with Tailwind refresh

### DIFF
--- a/public/allListing.html
+++ b/public/allListing.html
@@ -74,6 +74,30 @@
           </p>
         </div>
         <ul class="listing-list" data-listings></ul>
+        <nav
+          class="pagination"
+          data-pagination
+          aria-label="Listings pagination"
+          hidden
+        >
+          <p class="pagination__status" data-pagination-status>Page 1 of 1</p>
+          <div class="pagination__actions">
+            <button
+              class="pagination__button"
+              type="button"
+              data-pagination-prev
+            >
+              Previous
+            </button>
+            <button
+              class="pagination__button"
+              type="button"
+              data-pagination-next
+            >
+              Next
+            </button>
+          </div>
+        </nav>
       </section>
     </main>
 

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -12,21 +12,22 @@ body {
 
 body {
   min-height: 100vh;
-  font-family: "Inter", "Segoe UI", -apple-system, BlinkMacSystemFont, sans-serif;
-  background-color: #f4f4f5;
-  color: #1f2933;
-  line-height: 1.6;
   display: flex;
   flex-direction: column;
+  font-family: "Inter", "Segoe UI", -apple-system, BlinkMacSystemFont, sans-serif;
+  background-color: #f1f5f9;
+  color: #0f172a;
+  line-height: 1.6;
 }
 
 a {
   color: inherit;
   text-decoration: none;
+  transition: color 0.15s ease, background-color 0.15s ease;
 }
 
 a:hover,
-a:focus {
+a:focus-visible {
   text-decoration: underline;
 }
 
@@ -37,46 +38,49 @@ textarea {
 }
 
 img {
+  display: block;
   max-width: 100%;
   height: auto;
-  display: block;
 }
 
 .wrapper {
-  width: min(960px, 100%);
+  width: min(64rem, 100%);
   margin: 0 auto;
   padding: 0 1.5rem;
 }
 
 .site-header {
-  background-color: #ffffff;
-  border-bottom: 1px solid #e5e7eb;
+  width: 100%;
+  border-bottom: 1px solid #e2e8f0;
+  background-color: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(8px);
 }
 
 .site-header__inner {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  flex-wrap: wrap;
   padding: 1rem 0;
 }
 
 .brand {
-  font-weight: 700;
-  letter-spacing: 0.08em;
+  font-size: 0.875rem;
+  font-weight: 600;
   text-transform: uppercase;
-  font-size: 0.95rem;
+  letter-spacing: 0.2em;
+  color: #475569;
 }
 
 .site-nav__list {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 0.75rem;
   list-style: none;
   margin: 0;
   padding: 0;
-  flex-wrap: wrap;
 }
 
 .site-nav__link,
@@ -84,51 +88,61 @@ img {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.35rem;
-  padding: 0.4rem 0.75rem;
-  border-radius: 999px;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 9999px;
   border: 1px solid transparent;
-  font-size: 0.9rem;
-  background: transparent;
-  color: inherit;
-  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #475569;
+  transition: color 0.15s ease, background-color 0.15s ease;
+}
+
+.site-nav__link:hover,
+.site-nav__link:focus-visible {
+  background-color: #f1f5f9;
+  color: #1e293b;
 }
 
 .site-nav__link[aria-current="page"] {
-  background-color: #e5e7eb;
-  border-color: #d1d5db;
+  background-color: #f1f5f9;
+  border-color: #e2e8f0;
+  color: #0f172a;
 }
 
 .site-nav__button {
-  border-color: #d1d5db;
+  border-color: #e2e8f0;
   background-color: #ffffff;
+  color: #334155;
 }
 
 .site-nav__button:hover,
-.site-nav__button:focus {
-  background-color: #f3f4f6;
+.site-nav__button:focus-visible {
+  background-color: #f1f5f9;
 }
 
 .site-nav__user {
-  font-size: 0.85rem;
-  color: #4b5563;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  color: #64748b;
 }
 
 .badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
   background-color: #e0e7ff;
-  color: #1e3a8a;
-  font-size: 0.85rem;
+  color: #4338ca;
+  font-size: 0.75rem;
   font-weight: 600;
 }
 
 main {
   flex: 1;
-  padding: 2rem 0 3rem;
+  padding: 2.5rem 0;
 }
 
 .stack {
@@ -140,10 +154,10 @@ main {
 .hero-card,
 .section {
   background-color: #ffffff;
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 1rem;
   padding: 1.5rem;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
 }
 
 .hero-card > *:last-child,
@@ -151,31 +165,36 @@ main {
   margin-bottom: 0;
 }
 
-.hero-card h1,
-.section h1,
-.section h2,
-.section h3 {
-  margin-top: 0;
-  margin-bottom: 0.75rem;
+.listing-card {
+  background-color: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 1rem;
+  padding: 1.25rem;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .page-title {
-  margin-top: 0;
-  margin-bottom: 0.75rem;
-  font-size: clamp(1.75rem, 4vw, 2.25rem);
+  font-size: clamp(1.875rem, 3vw, 2.25rem);
+  font-weight: 600;
+  color: #0f172a;
+  margin: 0 0 0.75rem;
 }
 
 .page-lede {
   margin: 0 0 1.25rem;
-  color: #4b5563;
+  color: #475569;
 }
 
 .eyebrow {
-  text-transform: uppercase;
-  letter-spacing: 0.2em;
-  font-size: 0.75rem;
-  color: #6b7280;
   margin: 0 0 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #64748b;
 }
 
 .search-form {
@@ -184,59 +203,73 @@ main {
 
 .search-form__fields {
   display: flex;
-  gap: 0.75rem;
   flex-wrap: wrap;
+  gap: 0.75rem;
 }
 
 .search-form input[type="search"] {
   flex: 1;
   min-width: 220px;
-  padding: 0.6rem 0.75rem;
-  border: 1px solid #d1d5db;
-  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #cbd5f5;
+  border-radius: 0.75rem;
   background-color: #ffffff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.search-form input[type="search"]:focus-visible {
+  border-color: #6366f1;
+  outline: 2px solid rgba(99, 102, 241, 0.3);
+  outline-offset: 2px;
 }
 
 .button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.55rem 1.1rem;
-  border-radius: 8px;
+  gap: 0.5rem;
+  padding: 0.6rem 1rem;
+  border-radius: 0.75rem;
   border: none;
-  background-color: #2563eb;
+  background-color: #4f46e5;
   color: #ffffff;
+  font-size: 0.875rem;
   font-weight: 600;
   cursor: pointer;
-  text-decoration: none;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+  transition: background-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .button:hover,
-.button:focus {
-  background-color: #1d4ed8;
+.button:focus-visible {
+  background-color: #6366f1;
   text-decoration: none;
+  outline: 2px solid rgba(99, 102, 241, 0.3);
+  outline-offset: 2px;
 }
 
 .button[disabled] {
   opacity: 0.6;
   cursor: not-allowed;
+  outline: none;
 }
 
 .button--outline {
   background-color: #ffffff;
-  border: 1px solid #d1d5db;
-  color: #1f2933;
+  color: #1f2937;
+  border: 1px solid #d4d4d8;
 }
 
 .button--outline:hover,
-.button--outline:focus {
-  background-color: #f3f4f6;
+.button--outline:focus-visible {
+  background-color: #f4f4f5;
 }
 
 .section__actions {
   display: flex;
-  gap: 0.75rem;
   flex-wrap: wrap;
+  gap: 0.75rem;
   margin-top: 1.5rem;
 }
 
@@ -252,7 +285,7 @@ main {
 .section__status {
   margin: 0;
   font-size: 0.9rem;
-  color: #6b7280;
+  color: #64748b;
 }
 
 .section__status[data-tone="error"] {
@@ -263,10 +296,14 @@ main {
   color: #b45309;
 }
 
+.section__status[data-tone="success"] {
+  color: #047857;
+}
+
 .topics {
   display: flex;
-  gap: 0.5rem;
   flex-wrap: wrap;
+  gap: 0.5rem;
   margin-top: 1.25rem;
 }
 
@@ -274,16 +311,16 @@ main {
   display: inline-flex;
   align-items: center;
   padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  background-color: #e5e7eb;
+  border-radius: 9999px;
+  background-color: #e2e8f0;
   font-size: 0.8rem;
-  color: #374151;
+  color: #475569;
 }
 
 .form {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.25rem;
   margin-top: 1.5rem;
 }
 
@@ -292,15 +329,30 @@ main {
   font-weight: 600;
   font-size: 0.9rem;
   margin-bottom: 0.35rem;
+  color: #1f2933;
 }
 
 .form input,
 .form textarea {
   width: 100%;
   padding: 0.6rem 0.75rem;
-  border: 1px solid #d1d5db;
-  border-radius: 8px;
+  border: 1px solid #cbd5f5;
+  border-radius: 0.75rem;
   background-color: #ffffff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form input:focus-visible,
+.form textarea:focus-visible {
+  border-color: #6366f1;
+  outline: 2px solid rgba(99, 102, 241, 0.3);
+  outline-offset: 2px;
+}
+
+.form textarea {
+  min-height: 160px;
+  resize: vertical;
 }
 
 .form__checkbox {
@@ -308,10 +360,34 @@ main {
   align-items: center;
   gap: 0.5rem;
   font-size: 0.9rem;
+  color: #475569;
 }
 
 .form__checkbox input {
   width: auto;
+}
+
+.form__status {
+  margin: 0;
+  margin-top: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid #e2e8f0;
+  background-color: #f8fafc;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.form__status--error {
+  border-color: #fecaca;
+  background-color: #fef2f2;
+  color: #b91c1c;
+}
+
+.form__status--success {
+  border-color: #a7f3d0;
+  background-color: #ecfdf5;
+  color: #047857;
 }
 
 .hero-card--listing {
@@ -323,16 +399,9 @@ main {
   text-align: left;
 }
 
-@media (min-width: 720px) {
-  .hero-card--listing {
-    grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
-    align-items: start;
-  }
-}
-
 .hero-card__media {
-  border-radius: 10px;
-  background-color: #f3f4f6;
+  border-radius: 0.75rem;
+  background-color: #e2e8f0;
   min-height: 200px;
   display: flex;
   align-items: center;
@@ -364,46 +433,40 @@ main {
   }
 }
 
-.listing-card {
-  border: 1px solid #e5e7eb;
-  border-radius: 10px;
-  padding: 1rem;
-  background-color: #ffffff;
+.listing-card__header {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-}
-
-.listing-card__media {
-  border-radius: 8px;
-  overflow: hidden;
-  background-color: #f3f4f6;
-  aspect-ratio: 4 / 3;
+  gap: 0.4rem;
 }
 
 .listing-card__title {
   margin: 0;
   font-size: 1.1rem;
+  font-weight: 600;
+  color: #0f172a;
 }
 
 .listing-card__title a {
   text-decoration: none;
+  color: inherit;
+  transition: color 0.15s ease;
 }
 
 .listing-card__title a:hover,
-.listing-card__title a:focus {
+.listing-card__title a:focus-visible {
+  color: #4338ca;
   text-decoration: underline;
 }
 
 .listing-card__seller {
   margin: 0;
   font-size: 0.9rem;
-  color: #6b7280;
+  color: #64748b;
 }
 
 .listing-card__description {
   margin: 0;
-  color: #4b5563;
+  color: #475569;
   font-size: 0.95rem;
 }
 
@@ -412,7 +475,11 @@ main {
   flex-wrap: wrap;
   gap: 0.75rem;
   font-size: 0.85rem;
-  color: #6b7280;
+  color: #64748b;
+}
+
+.listing-card__meta strong {
+  font-weight: 600;
 }
 
 .listing-card__meta--stack {
@@ -422,8 +489,21 @@ main {
 
 .listing-card--empty {
   text-align: center;
-  color: #6b7280;
+  color: #64748b;
   font-size: 0.95rem;
+}
+
+.listing-card__media {
+  border-radius: 0.75rem;
+  overflow: hidden;
+  background-color: #e2e8f0;
+  aspect-ratio: 4 / 3;
+}
+
+.listing-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 .listing-bids {
@@ -435,15 +515,22 @@ main {
   gap: 0.75rem;
 }
 
-.listing-bids li {
-  border: 1px solid #e5e7eb;
-  border-radius: 8px;
+.listing-bid {
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
   padding: 0.75rem 1rem;
-  background-color: #f9fafb;
+  background-color: #f8fafc;
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
   gap: 0.5rem;
+  font-size: 0.95rem;
+  color: #1f2933;
+}
+
+.listing-bid--empty {
+  justify-content: center;
+  color: #64748b;
 }
 
 .profile__credits {
@@ -452,7 +539,7 @@ main {
 
 .site-footer {
   background-color: #ffffff;
-  border-top: 1px solid #e5e7eb;
+  border-top: 1px solid #e2e8f0;
 }
 
 .site-footer__inner {
@@ -461,5 +548,147 @@ main {
   justify-content: center;
   padding: 1.5rem 0;
   font-size: 0.85rem;
-  color: #6b7280;
+  color: #64748b;
+}
+
+.bid-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.bid-summary__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.bid-notice {
+  margin: 0 0 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid #e2e8f0;
+  background-color: #f8fafc;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.bid-notice[data-tone="warning"] {
+  border-color: #fde68a;
+  background-color: #fffbeb;
+  color: #b45309;
+}
+
+.bid-notice[data-tone="error"] {
+  border-color: #fecaca;
+  background-color: #fef2f2;
+  color: #b91c1c;
+}
+
+.bid-notice[data-tone="success"] {
+  border-color: #a7f3d0;
+  background-color: #ecfdf5;
+  color: #047857;
+}
+
+.bid-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.bid-form__fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.bid-form__field {
+  flex: 1;
+  min-width: 200px;
+}
+
+.bid-form__field input {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid #cbd5f5;
+  border-radius: 0.75rem;
+  background-color: #ffffff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.bid-form__field input:focus-visible {
+  border-color: #6366f1;
+  outline: 2px solid rgba(99, 102, 241, 0.3);
+  outline-offset: 2px;
+}
+
+.bid-form__help {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.pagination {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.pagination__status {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.pagination__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.pagination__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.85rem;
+  border-radius: 0.75rem;
+  border: 1px solid #d4d4d8;
+  background-color: #ffffff;
+  color: #334155;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.pagination__button:hover,
+.pagination__button:focus-visible {
+  background-color: #f1f5f9;
+  border-color: #cbd5f5;
+  outline: 2px solid rgba(99, 102, 241, 0.3);
+  outline-offset: 2px;
+}
+
+.pagination__button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+  outline: none;
+}
+
+@media (min-width: 720px) {
+  .hero-card--listing {
+    grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
+    align-items: start;
+  }
 }

--- a/public/assets/js/allListing.js
+++ b/public/assets/js/allListing.js
@@ -10,15 +10,118 @@ const listElement = document.querySelector("[data-listings]");
 const resultsCount = document.querySelector("[data-results-count]");
 const statusElement = document.querySelector("[data-listings-status]");
 const searchForm = document.querySelector("[data-search-form]");
-const initialParams = new URLSearchParams(window.location.search);
-const initialQuery = initialParams.get("query");
+const paginationElement = document.querySelector("[data-pagination]");
+const paginationStatus = document.querySelector("[data-pagination-status]");
+const paginationPrev = document.querySelector("[data-pagination-prev]");
+const paginationNext = document.querySelector("[data-pagination-next]");
 
+const initialParams = new URLSearchParams(window.location.search);
+const initialQuery = initialParams.get("query") || "";
+const initialPage = Math.max(Number(initialParams.get("page")) || 1, 1);
+
+const numberFormatter = new Intl.NumberFormat();
+
+const DEFAULT_LIMIT = 50;
 const DEFAULT_QUERY = {
   sort: "created",
   sortOrder: "desc",
   _seller: true,
   _bids: true,
-  limit: 40,
+  limit: DEFAULT_LIMIT,
+};
+
+const state = {
+  query: String(initialQuery).trim(),
+  page: initialPage,
+};
+
+const updateSearchField = () => {
+  if (!searchForm) {
+    return;
+  }
+
+  const input = searchForm.querySelector('input[name="query"]');
+  if (input) {
+    input.value = state.query;
+  }
+};
+
+updateSearchField();
+
+const updateQueryString = () => {
+  const params = new URLSearchParams();
+  if (state.query) {
+    params.set("query", state.query);
+  }
+  if (state.page > 1) {
+    params.set("page", String(state.page));
+  }
+  const queryString = params.toString();
+  const url = `${window.location.pathname}${
+    queryString ? `?${queryString}` : ""
+  }${window.location.hash}`;
+  window.history.replaceState({}, "", url);
+};
+
+const setStatus = (message, tone = "info") => {
+  if (!statusElement) {
+    return;
+  }
+
+  statusElement.textContent = message;
+  if (!message) {
+    statusElement.hidden = true;
+    delete statusElement.dataset.tone;
+    return;
+  }
+
+  statusElement.hidden = false;
+  statusElement.dataset.tone = tone;
+};
+
+const updatePagination = (meta, itemsLength) => {
+  if (!paginationElement) {
+    return;
+  }
+
+  const limit = Number(meta?.limit) || DEFAULT_LIMIT;
+  const page = Number(meta?.page) || state.page || 1;
+  const total = Number(meta?.total);
+  const hasTotal = Number.isFinite(total) && total >= 0;
+  const hasResults = hasTotal ? total > 0 : itemsLength > 0;
+
+  if (!hasResults) {
+    paginationElement.hidden = true;
+    return;
+  }
+
+  const totalPages = hasTotal
+    ? Math.max(1, Math.ceil(total / limit))
+    : itemsLength < limit
+      ? page
+      : undefined;
+  const isFirstPage = page <= 1;
+  const isLastPage = totalPages ? page >= totalPages : itemsLength < limit;
+
+  if (paginationStatus) {
+    const pageLabel = totalPages
+      ? `Page ${page} of ${totalPages}`
+      : `Page ${page}`;
+    const resultLabel = hasTotal
+      ? `${numberFormatter.format(total)} results`
+      : `${itemsLength} results`;
+    paginationStatus.textContent = `${pageLabel} · ${resultLabel}`;
+  }
+
+  if (paginationPrev) {
+    paginationPrev.disabled = isFirstPage;
+  }
+
+  if (paginationNext) {
+    paginationNext.disabled = isLastPage;
+  }
+
+  paginationElement.hidden = false;
 };
 
 const createListingCard = (listing) => {
@@ -38,7 +141,7 @@ const createListingCard = (listing) => {
     </div>
     <p class="listing-card__description">${listing.description || "No description provided."}</p>
     <div class="listing-card__meta">
-      <span><strong>${bids}</strong> bids</span>
+      <span><strong>${numberFormatter.format(bids)}</strong> bids</span>
       <span>Ends ${formatDate(listing.endsAt)}</span>
     </div>
   `;
@@ -58,7 +161,7 @@ const createListingCard = (listing) => {
   return listItem;
 };
 
-const renderListings = (items) => {
+const renderListings = (items, meta) => {
   if (!listElement) {
     return;
   }
@@ -70,7 +173,8 @@ const renderListings = (items) => {
     emptyItem.className = "listing-card listing-card--empty";
     emptyItem.textContent = "No listings found. Try a different search.";
     listElement.append(emptyItem);
-    renderCount(resultsCount, 0);
+    renderCount(resultsCount, meta?.total ?? 0);
+    updatePagination(meta, 0);
     return;
   }
 
@@ -80,46 +184,51 @@ const renderListings = (items) => {
   });
 
   listElement.append(fragment);
-  renderCount(resultsCount, items.length);
+  renderCount(resultsCount, meta?.total ?? items.length);
+  updatePagination(meta, items.length);
 };
 
-const setStatus = (message, tone = "info") => {
-  if (!statusElement) {
-    return;
-  }
+const loadListings = async ({
+  query = state.query,
+  page = state.page,
+} = {}) => {
+  state.query = String(query || "").trim();
+  state.page = Math.max(Number(page) || 1, 1);
+  updateSearchField();
+  updateQueryString();
 
-  statusElement.textContent = message;
-  if (!message) {
-    statusElement.hidden = true;
-    delete statusElement.dataset.tone;
-    return;
-  }
-
-  statusElement.hidden = false;
-  statusElement.dataset.tone = tone;
-};
-
-const loadListings = async (query) => {
   setStatus("Loading listings…", "info");
 
-  try {
-    const response = query
-      ? await searchListings(query, DEFAULT_QUERY)
-      : await getListings(DEFAULT_QUERY);
+  const params = { ...DEFAULT_QUERY, page: state.page };
 
-    const items =
-      Array.isArray(response?.data) && response.data.length
-        ? response.data
-        : [];
+  try {
+    const response = state.query
+      ? await searchListings(state.query, params)
+      : await getListings(params);
+
+    const items = Array.isArray(response?.data) ? response.data : [];
+    const meta = {
+      page: Number(response?.meta?.page) || state.page,
+      limit: Number(response?.meta?.limit) || params.limit,
+      total:
+        response?.meta?.total !== undefined
+          ? Number(response.meta.total)
+          : response?.meta?.total,
+    };
+
+    state.page = meta.page;
 
     if (!items.length) {
-      setStatus("No listings matched your search.", "warning");
-      renderListings([]);
+      const message = state.query
+        ? "No listings matched your search."
+        : "No listings available right now.";
+      setStatus(message, "warning");
+      renderListings([], { ...meta, total: meta.total ?? 0 });
       return;
     }
 
     setStatus("");
-    renderListings(items);
+    renderListings(items, meta);
   } catch (error) {
     console.error(error);
     setStatus(
@@ -127,37 +236,36 @@ const loadListings = async (query) => {
         "We couldn't load listings right now. Showing examples instead.",
       "error",
     );
-    renderListings(fallbackListings);
+    renderListings(fallbackListings, {
+      page: 1,
+      limit: DEFAULT_LIMIT,
+      total: fallbackListings.length,
+    });
   }
 };
 
 if (searchForm) {
-  if (initialQuery) {
-    const input = searchForm.querySelector('input[name="query"]');
-    if (input) {
-      input.value = initialQuery;
-    }
-  }
-
   searchForm.addEventListener("submit", (event) => {
     event.preventDefault();
     const formData = new FormData(searchForm);
     const query = String(formData.get("query") || "").trim();
 
-    if (!query) {
-      loadListings();
-      return;
-    }
-
-    loadListings(query);
+    loadListings({ query, page: 1 });
   });
 }
 
-if (initialQuery) {
-  loadListings(initialQuery);
-} else {
-  loadListings();
-}
+paginationPrev?.addEventListener("click", () => {
+  if (state.page <= 1) {
+    return;
+  }
+  loadListings({ page: state.page - 1 });
+});
+
+paginationNext?.addEventListener("click", () => {
+  loadListings({ page: state.page + 1 });
+});
+
+loadListings();
 
 window.addEventListener("unload", () => {
   if (typeof teardown === "function") {

--- a/public/assets/js/listing.js
+++ b/public/assets/js/listing.js
@@ -1,6 +1,6 @@
 /* eslint-env browser */
 
-import { getListing } from "./shared/api.js";
+import { createBid, getListing, getStoredAuth } from "./shared/api.js";
 import { fallbackListings } from "./shared/data.js";
 import { formatDate, initPageChrome } from "./shared/page.js";
 
@@ -13,12 +13,31 @@ const descriptionElements = document.querySelectorAll(
 const sellerElements = document.querySelectorAll("[data-listing-seller]");
 const deadlineElements = document.querySelectorAll("[data-listing-deadline]");
 const bidCountElements = document.querySelectorAll("[data-listing-bid-count]");
+const highestBidElements = document.querySelectorAll(
+  "[data-listing-highest-bid]",
+);
+const nextMinimumElements = document.querySelectorAll(
+  "[data-listing-next-minimum]",
+);
 const statusElement = document.querySelector("[data-listing-status]");
 const imageElement = document.querySelector("[data-listing-image]");
 const bidsContainer = document.querySelector("[data-bid-list]");
+const bidForm = document.querySelector("[data-bid-form]");
+const bidAmountInput = document.querySelector("[data-bid-amount]");
+const bidSubmitButton =
+  bidForm?.querySelector("[data-bid-submit]") ||
+  bidForm?.querySelector('button[type="submit"]');
+const bidStatus = document.querySelector("[data-bid-status]");
+const bidNotice = document.querySelector("[data-bid-notice]");
 
 const params = new URLSearchParams(window.location.search);
 const listingId = params.get("id");
+
+let currentListing;
+
+const numberFormatter = new Intl.NumberFormat();
+
+const formatCredits = (value) => `${numberFormatter.format(value)} credits`;
 
 const setStatus = (message, tone = "info") => {
   if (!statusElement) {
@@ -55,6 +74,155 @@ const assignTextContent = (elements, value) => {
   }
 };
 
+const getHighestBidAmount = (listing) => {
+  if (!listing?.bids?.length) {
+    return 0;
+  }
+
+  return listing.bids.reduce((max, bid) => {
+    const amount = Number(bid.amount);
+    if (!Number.isFinite(amount)) {
+      return max;
+    }
+    return amount > max ? amount : max;
+  }, 0);
+};
+
+const getNextMinimumBidAmount = (listing) => {
+  const highest = getHighestBidAmount(listing);
+  return highest > 0 ? highest + 1 : 1;
+};
+
+const setBidNotice = (message, tone = "info") => {
+  if (!bidNotice) {
+    return;
+  }
+
+  if (!message) {
+    bidNotice.hidden = true;
+    bidNotice.textContent = "";
+    delete bidNotice.dataset.tone;
+    return;
+  }
+
+  bidNotice.hidden = false;
+  bidNotice.textContent = message;
+  bidNotice.dataset.tone = tone;
+};
+
+const setBidStatus = (message, tone = "info") => {
+  if (!bidStatus) {
+    return;
+  }
+
+  if (!message) {
+    bidStatus.hidden = true;
+    bidStatus.textContent = "";
+    bidStatus.className = "form__status";
+    return;
+  }
+
+  const classes = ["form__status"];
+  if (tone === "error") {
+    classes.push("form__status--error");
+  } else if (tone === "success") {
+    classes.push("form__status--success");
+  }
+
+  bidStatus.hidden = false;
+  bidStatus.textContent = message;
+  bidStatus.className = classes.join(" ");
+};
+
+const isListingClosed = (listing) => {
+  if (!listing?.endsAt) {
+    return false;
+  }
+
+  const ends = new Date(listing.endsAt);
+  if (Number.isNaN(ends.getTime())) {
+    return false;
+  }
+
+  return ends.getTime() <= Date.now();
+};
+
+const updateBidSummary = () => {
+  const highest = getHighestBidAmount(currentListing);
+  assignTextContent(
+    highestBidElements,
+    highest > 0 ? formatCredits(highest) : "No bids yet",
+  );
+
+  const nextMinimum = getNextMinimumBidAmount(currentListing);
+  assignTextContent(nextMinimumElements, numberFormatter.format(nextMinimum));
+
+  if (bidAmountInput) {
+    const minimum = Math.max(1, nextMinimum);
+    bidAmountInput.min = String(minimum);
+    bidAmountInput.setAttribute("min", String(minimum));
+    if (!bidAmountInput.value) {
+      bidAmountInput.placeholder = numberFormatter.format(minimum);
+    }
+  }
+};
+
+const updateBidFormAvailability = () => {
+  if (!bidForm) {
+    return;
+  }
+
+  const auth = getStoredAuth();
+  const signedIn = Boolean(auth?.accessToken);
+  const sellerName = currentListing?.seller?.name;
+  const authName = typeof auth?.name === "string" ? auth.name : "";
+  const isSeller =
+    signedIn &&
+    sellerName &&
+    authName.toLowerCase() === sellerName.toLowerCase();
+  const closed = isListingClosed(currentListing);
+  const listingAvailable =
+    Boolean(listingId) &&
+    Boolean(currentListing?.id) &&
+    currentListing.id === listingId;
+
+  let message = "";
+  let tone = "info";
+
+  if (!listingId) {
+    message = "We couldn't find this listing, so bidding is unavailable.";
+    tone = "warning";
+  } else if (!listingAvailable) {
+    message = "Bidding is disabled while we show an example listing.";
+    tone = "warning";
+  } else if (!signedIn) {
+    message = "Log in to place a bid.";
+  } else if (isSeller) {
+    message = "You cannot bid on your own listing.";
+    tone = "warning";
+  } else if (closed) {
+    message = "This auction has ended. Bidding is closed.";
+    tone = "warning";
+  }
+
+  const allow =
+    !message && signedIn && listingAvailable && !isSeller && !closed;
+
+  if (bidAmountInput) {
+    bidAmountInput.disabled = !allow;
+  }
+
+  if (bidSubmitButton) {
+    bidSubmitButton.disabled = !allow;
+  }
+
+  setBidNotice(message, tone);
+
+  if (!allow) {
+    setBidStatus("");
+  }
+};
+
 const renderBids = (bids = []) => {
   if (!bidsContainer) {
     return;
@@ -78,10 +246,11 @@ const renderBids = (bids = []) => {
       const item = document.createElement("li");
       item.className = "listing-bid";
       const bidder = bid.bidder?.name || "Anonymous";
+      const created = bid.created ? new Date(bid.created).toISOString() : "";
       item.innerHTML = `
         <span>${bidder}</span>
-        <strong>${new Intl.NumberFormat().format(bid.amount)} credits</strong>
-        <time datetime="${bid.created}">${formatDate(bid.created)}</time>
+        <strong>${formatCredits(Number(bid.amount) || 0)}</strong>
+        <time datetime="${created}">${formatDate(bid.created)}</time>
       `;
       fragment.append(item);
     });
@@ -93,6 +262,8 @@ const hydrateListing = (listing, { updateTitle = true } = {}) => {
   if (!listing) {
     return;
   }
+
+  currentListing = listing;
 
   assignTextContent(titleElements, listing.title);
   if (listing.title && updateTitle) {
@@ -132,7 +303,7 @@ const hydrateListing = (listing, { updateTitle = true } = {}) => {
   }
 
   const bids = listing._count?.bids ?? listing.bids?.length ?? 0;
-  assignTextContent(bidCountElements, new Intl.NumberFormat().format(bids));
+  assignTextContent(bidCountElements, numberFormatter.format(bids));
 
   if (imageElement) {
     const media = listing.media?.[0];
@@ -148,9 +319,12 @@ const hydrateListing = (listing, { updateTitle = true } = {}) => {
   }
 
   renderBids(listing.bids || []);
+  updateBidSummary();
+  updateBidFormAvailability();
+  setBidStatus("");
 };
 
-const loadListing = async () => {
+const loadListing = async ({ silent = false } = {}) => {
   if (!listingId) {
     setStatus(
       "We couldn't find that listing. Showing an example instead.",
@@ -160,7 +334,9 @@ const loadListing = async () => {
     return;
   }
 
-  setStatus("Loading listing details…", "info");
+  if (!silent) {
+    setStatus("Loading listing details…", "info");
+  }
 
   try {
     const response = await getListing(listingId, {
@@ -187,9 +363,84 @@ const loadListing = async () => {
   }
 };
 
+const handleAuthChanged = () => {
+  updateBidFormAvailability();
+};
+
+window.addEventListener("auth:changed", handleAuthChanged);
+
+if (bidForm) {
+  bidForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    if (bidForm.dataset.submitting === "true") {
+      return;
+    }
+
+    if (!listingId || !currentListing || currentListing.id !== listingId) {
+      setBidStatus(
+        "Bidding is unavailable right now. Please refresh and try again.",
+        "error",
+      );
+      return;
+    }
+
+    const formData = new FormData(bidForm);
+    const rawAmount = Number(formData.get("amount"));
+
+    if (!Number.isFinite(rawAmount) || rawAmount <= 0) {
+      setBidStatus("Enter a valid bid amount in credits.", "error");
+      return;
+    }
+
+    const amount = Math.floor(rawAmount);
+    const minimum = getNextMinimumBidAmount(currentListing);
+
+    if (amount < minimum) {
+      setBidStatus(
+        `Your bid must be at least ${formatCredits(minimum)}.`,
+        "error",
+      );
+      return;
+    }
+
+    try {
+      bidForm.dataset.submitting = "true";
+      setBidStatus("Placing your bid…", "info");
+
+      await createBid(listingId, { amount });
+
+      setBidStatus("Bid placed! Good luck.", "success");
+      bidForm.reset();
+      await loadListing({ silent: true });
+    } catch (error) {
+      console.error(error);
+      setBidStatus(
+        error.message ||
+          "We couldn't place your bid right now. Please try again.",
+        "error",
+      );
+    } finally {
+      delete bidForm.dataset.submitting;
+      updateBidSummary();
+      updateBidFormAvailability();
+    }
+  });
+}
+
+const handleBidInput = () => {
+  if (bidStatus && bidStatus.className.includes("form__status--error")) {
+    setBidStatus("");
+  }
+};
+
+bidAmountInput?.addEventListener("input", handleBidInput);
+
 loadListing();
 
 window.addEventListener("unload", () => {
+  window.removeEventListener("auth:changed", handleAuthChanged);
+  bidAmountInput?.removeEventListener("input", handleBidInput);
   if (typeof teardown === "function") {
     teardown();
   }

--- a/public/assets/js/shared/api.js
+++ b/public/assets/js/shared/api.js
@@ -180,6 +180,13 @@ export const getListing = (id, params) =>
     requireAuth: false,
   });
 
+export const createBid = (id, payload) =>
+  request(`/auction/listings/${encodeURIComponent(id)}/bids`, {
+    method: "POST",
+    body: payload,
+    requireAuth: true,
+  });
+
 export const getProfile = (name, params) =>
   request(`/auction/profiles/${encodeURIComponent(name)}${buildQuery(params)}`);
 

--- a/public/listing.html
+++ b/public/listing.html
@@ -62,6 +62,10 @@
             <span>Seller: <strong data-listing-seller>Loading…</strong></span>
             <span>Ends <time data-listing-deadline>Loading…</time></span>
             <span><strong data-listing-bid-count>0</strong> bids</span>
+            <span>
+              Highest bid:
+              <strong data-listing-highest-bid>Checking…</strong>
+            </span>
           </div>
           <p class="section__status" data-listing-status hidden></p>
           <div class="section__actions">
@@ -70,6 +74,55 @@
             >
           </div>
         </div>
+      </section>
+
+      <section class="section">
+        <div class="section__header">
+          <h2>Place a bid</h2>
+          <p class="section__status">
+            Next minimum: <strong data-listing-next-minimum>1</strong> credits
+          </p>
+        </div>
+        <div class="bid-summary">
+          <div class="bid-summary__meta">
+            <span>
+              Highest bid:
+              <strong data-listing-highest-bid>Checking…</strong>
+            </span>
+            <span>
+              Minimum bid:
+              <strong data-listing-next-minimum>1</strong> credits
+            </span>
+          </div>
+        </div>
+        <p class="bid-notice" data-bid-notice hidden></p>
+        <form class="bid-form" data-bid-form novalidate>
+          <div class="bid-form__fields">
+            <label class="bid-form__field">
+              <span>Bid amount (credits)</span>
+              <input
+                class="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-base shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                type="number"
+                name="amount"
+                min="1"
+                step="1"
+                inputmode="numeric"
+                autocomplete="off"
+                data-bid-amount
+                required
+              />
+            </label>
+            <button class="button" type="submit" data-bid-submit>
+              Place bid
+            </button>
+          </div>
+          <p class="bid-form__help">
+            Enter at least
+            <strong data-listing-next-minimum>1</strong>
+            credits.
+          </p>
+          <p class="form__status" data-bid-status hidden></p>
+        </form>
       </section>
 
       <section class="section">

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -2,75 +2,367 @@
 @tailwind components;
 @tailwind utilities;
 
-/*
-  This Tailwind source mirrors the lightweight styles defined in
-  public/assets/css/style.css so future builds remain consistent.
-*/
-
 @layer base {
   *,
   *::before,
   *::after {
-    box-sizing: border-box;
+    @apply box-border;
   }
 
   html,
   body {
-    margin: 0;
-    padding: 0;
+    @apply m-0 p-0;
   }
 
   body {
-    min-height: 100vh;
-    font-family:
-      "Inter",
-      "Segoe UI",
-      -apple-system,
-      BlinkMacSystemFont,
-      sans-serif;
-    background-color: #f4f4f5;
-    color: #1f2933;
-    line-height: 1.6;
+    @apply flex min-h-screen flex-col bg-slate-100 font-sans leading-relaxed text-slate-900;
   }
 
   a {
-    color: inherit;
-    text-decoration: none;
+    @apply text-inherit no-underline transition duration-150 ease-in-out;
+  }
+
+  a:hover,
+  a:focus-visible {
+    @apply underline;
+  }
+
+  button,
+  input,
+  textarea {
+    @apply font-sans;
   }
 
   img {
-    max-width: 100%;
-    display: block;
+    @apply block h-auto max-w-full;
   }
 }
 
 @layer components {
   .wrapper {
-    width: min(960px, 100%);
-    margin-left: auto;
-    margin-right: auto;
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
+    @apply mx-auto w-full max-w-5xl px-6;
   }
 
   .site-header {
-    @apply w-full border-b border-gray-200 bg-white;
+    @apply w-full border-b border-slate-200 bg-white/80 backdrop-blur;
   }
 
-  .hero-card,
-  .section,
-  .listing-card {
-    @apply border border-gray-200 bg-white;
-    border-radius: 0.75rem;
-    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  .site-header__inner {
+    @apply flex flex-wrap items-center justify-between gap-4 py-4;
+  }
+
+  .brand {
+    @apply text-sm font-semibold uppercase tracking-[0.2em] text-slate-600;
+  }
+
+  .site-nav__list {
+    @apply m-0 flex list-none flex-wrap items-center gap-3 p-0;
+  }
+
+  .site-nav__link,
+  .site-nav__button {
+    @apply inline-flex items-center justify-center gap-2 rounded-full border border-transparent px-3 py-2 text-sm font-medium text-slate-600 transition hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500;
+  }
+
+  .site-nav__link {
+    @apply hover:bg-slate-100;
+  }
+
+  .site-nav__link[aria-current="page"] {
+    @apply border-slate-200 bg-slate-100 text-slate-900;
+  }
+
+  .site-nav__button {
+    @apply border-slate-200 bg-white text-slate-700 hover:bg-slate-100;
+  }
+
+  .site-nav__user {
+    @apply text-xs uppercase tracking-[0.3em] text-slate-500;
+  }
+
+  .badge {
+    @apply inline-flex items-center justify-center rounded-full bg-indigo-100 px-3 py-1 text-xs font-semibold text-indigo-700;
+  }
+
+  main {
+    @apply flex-1 py-10;
+  }
+
+  .stack {
+    @apply flex flex-col gap-8;
   }
 
   .hero-card,
   .section {
-    padding: 1.5rem;
+    @apply rounded-2xl border border-slate-200 bg-white p-6 shadow-sm;
   }
 
   .listing-card {
-    padding: 1rem;
+    @apply flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm;
+  }
+
+  .hero-card > *:last-child,
+  .section > *:last-child {
+    @apply mb-0;
+  }
+
+  .page-title {
+    @apply text-3xl font-semibold text-slate-900 md:text-4xl;
+  }
+
+  .page-lede {
+    @apply text-base text-slate-600;
+  }
+
+  .eyebrow {
+    @apply mb-3 text-xs font-semibold uppercase tracking-[0.35em] text-slate-500;
+  }
+
+  .search-form {
+    @apply mt-4;
+  }
+
+  .search-form__fields {
+    @apply flex flex-wrap gap-3;
+  }
+
+  .search-form input[type="search"] {
+    @apply min-w-[220px] flex-1 rounded-lg border border-slate-300 bg-white px-3 py-2 text-base shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200;
+  }
+
+  .button {
+    @apply inline-flex items-center justify-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 disabled:cursor-not-allowed disabled:opacity-60;
+  }
+
+  .button--outline {
+    @apply border border-slate-300 bg-white text-slate-700 hover:bg-slate-100;
+  }
+
+  .section__actions {
+    @apply mt-6 flex flex-wrap gap-3;
+  }
+
+  .section__header {
+    @apply mb-5 flex flex-wrap items-center justify-between gap-3;
+  }
+
+  .section__status {
+    @apply text-sm text-slate-600;
+  }
+
+  .section__status[data-tone="error"] {
+    @apply text-red-600;
+  }
+
+  .section__status[data-tone="warning"] {
+    @apply text-amber-600;
+  }
+
+  .topics {
+    @apply mt-5 flex flex-wrap gap-2;
+  }
+
+  .topic-pill {
+    @apply inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600;
+  }
+
+  .form {
+    @apply mt-6 flex flex-col gap-5;
+  }
+
+  .form label span {
+    @apply mb-2 block text-sm font-semibold text-slate-700;
+  }
+
+  .form input,
+  .form textarea {
+    @apply w-full rounded-lg border border-slate-300 bg-white px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200;
+  }
+
+  .form textarea {
+    @apply min-h-[160px];
+  }
+
+  .form__checkbox {
+    @apply flex items-center gap-2 text-sm text-slate-600;
+  }
+
+  .form__checkbox input {
+    @apply w-auto;
+  }
+
+  .form__status {
+    @apply mt-2 rounded-lg border border-slate-200 bg-slate-50 px-4 py-2 text-sm text-slate-600;
+  }
+
+  .form__status--error {
+    @apply border-red-200 bg-red-50 text-red-700;
+  }
+
+  .form__status--success {
+    @apply border-emerald-200 bg-emerald-50 text-emerald-700;
+  }
+
+  .hero-card--listing {
+    @apply grid gap-6;
+  }
+
+  .hero-card--left {
+    @apply text-left;
+  }
+
+  .hero-card__media {
+    @apply flex min-h-[200px] items-center justify-center overflow-hidden rounded-xl bg-slate-100;
+  }
+
+  .hero-card__media img[hidden] {
+    display: none;
+  }
+
+  .hero-card__body {
+    @apply flex flex-col gap-4;
+  }
+
+  .listing-list {
+    @apply grid list-none gap-4 p-0;
+  }
+
+  .listing-card__header {
+    @apply flex flex-col gap-1;
+  }
+
+  .listing-card__title {
+    @apply m-0 text-lg font-semibold text-slate-900;
+  }
+
+  .listing-card__title a {
+    @apply no-underline transition hover:text-indigo-600 hover:underline;
+  }
+
+  .listing-card__seller {
+    @apply m-0 text-sm text-slate-500;
+  }
+
+  .listing-card__description {
+    @apply m-0 text-base text-slate-600;
+  }
+
+  .listing-card__meta {
+    @apply flex flex-wrap gap-3 text-sm text-slate-500;
+  }
+
+  .listing-card__meta--stack {
+    @apply flex-col items-start;
+  }
+
+  .listing-card--empty {
+    @apply text-center text-sm text-slate-500;
+  }
+
+  .listing-card__media {
+    @apply aspect-[4/3] overflow-hidden rounded-xl bg-slate-100;
+  }
+
+  .listing-card__body {
+    @apply flex flex-col gap-3;
+  }
+
+  .listing-bids {
+    @apply flex list-none flex-col gap-3 p-0;
+  }
+
+  .listing-bid {
+    @apply flex flex-wrap justify-between gap-2 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700;
+  }
+
+  .listing-bid--empty {
+    @apply justify-center text-slate-500;
+  }
+
+  .profile__credits {
+    @apply font-semibold;
+  }
+
+  .site-footer {
+    @apply border-t border-slate-200 bg-white;
+  }
+
+  .site-footer__inner {
+    @apply flex items-center justify-center py-6 text-sm text-slate-500;
+  }
+
+  .bid-summary {
+    @apply flex flex-wrap items-baseline justify-between gap-3 text-sm text-slate-600;
+  }
+
+  .bid-summary__meta {
+    @apply flex flex-wrap gap-3;
+  }
+
+  .bid-notice {
+    @apply rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600;
+  }
+
+  .bid-notice[data-tone="warning"] {
+    @apply border-amber-200 bg-amber-50 text-amber-700;
+  }
+
+  .bid-notice[data-tone="error"] {
+    @apply border-red-200 bg-red-50 text-red-700;
+  }
+
+  .bid-notice[data-tone="success"] {
+    @apply border-emerald-200 bg-emerald-50 text-emerald-700;
+  }
+
+  .bid-form {
+    @apply mt-4 flex flex-col gap-4;
+  }
+
+  .bid-form__fields {
+    @apply flex flex-wrap gap-3;
+  }
+
+  .bid-form__field {
+    @apply min-w-[200px] flex-1;
+  }
+
+  .bid-form__help {
+    @apply text-sm text-slate-500;
+  }
+
+  .pagination {
+    @apply mt-6 flex flex-wrap items-center justify-between gap-3;
+  }
+
+  .pagination__status {
+    @apply text-sm text-slate-600;
+  }
+
+  .pagination__actions {
+    @apply flex items-center gap-2;
+  }
+
+  .pagination__button {
+    @apply inline-flex items-center justify-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 disabled:cursor-not-allowed disabled:opacity-60;
+  }
+
+  @media (min-width: 720px) {
+    .hero-card--listing {
+      grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
+      align-items: start;
+    }
+  }
+
+  @media (min-width: 640px) {
+    .listing-list {
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    }
+  }
+}
+
+@layer utilities {
+  .section__status[data-tone="success"] {
+    @apply text-emerald-600;
   }
 }


### PR DESCRIPTION
## Summary
- add a bidding workflow to listing pages, including the API client, form, and UI state handling
- introduce paginated listing browsing with query-aware navigation limited to 50 items per page
- refresh the Tailwind design tokens and compiled CSS to support the new bid and pagination components

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e8b07621688321856d409d6025bc89